### PR TITLE
Update 1_create_conjur_namespace.sh

### DIFF
--- a/1_create_conjur_namespace.sh
+++ b/1_create_conjur_namespace.sh
@@ -9,7 +9,7 @@ set_namespace default
 
 if [[ $PLATFORM == openshift ]]; then
   echo "Logging in as cluster admin..."
-  oc login -u system:admin
+  oc login -u $CONJUR_OSHIFT_ADMIN
 fi
 
 if has_namespace "$CONJUR_NAMESPACE_NAME"; then


### PR DESCRIPTION
Changed `system:admin` to use the `$CONJUR_OSHIFT_ADMIN` variable instead.

In Minishift situations, `system:admin` is not allowed to basic auth and this will cause errors.