### PR TITLE
Update test_gke_entrypoint.sh

### DIFF
--- a/test_gke_entrypoint.sh
+++ b/test_gke_entrypoint.sh
@@ -58,9 +58,15 @@ function relaunchMaster() {
 # This means another parallel build is using the image and we should
 # just untag it to be deleted by the later job
 function deleteRegistryImage() {
-  local image=$1
-
-  gcloud container images delete -q "$image" || gcloud container images untag -q "$image" || true
+  local image_and_tag=$1
+  
+  IFS=':' read -r -a array <<< $image_and_tag
+  local image="${array[0]}"
+  local tag="${array[1]}"
+    
+  if gcloud container images list-tags $image | grep $tag; then
+    gcloud container images delete --force-delete-tags -q $image_and_tag
+  fi
 }
 
 main


### PR DESCRIPTION
Update the method that deletes images pushed to GKE in the course of testing this repo to match what is currently being used in `cyberark/conjur`.