### PR TITLE
Append namespace to authenticator ClusterRole

### DIFF
--- a/1_create_conjur_namespace.sh
+++ b/1_create_conjur_namespace.sh
@@ -34,12 +34,13 @@ if ! has_serviceaccount $CONJUR_SERVICEACCOUNT_NAME; then
   $cli create serviceaccount $CONJUR_SERVICEACCOUNT_NAME -n $CONJUR_NAMESPACE_NAME
 fi
 
-$cli delete --ignore-not-found clusterrole conjur-authenticator
+$cli delete --ignore-not-found clusterrole conjur-authenticator-$CONJUR_NAMESPACE_NAME
 
 # Grant default service account permissions it needs for authn-k8s to:
 # 1) get + list pods (to verify pod names)
 # 2) create + get pods/exec (to inject cert into app sidecar)
-$cli apply -f ./$PLATFORM/conjur-authenticator-role.yaml
+sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" ./$PLATFORM/conjur-authenticator-role.yaml |
+  $cli apply -f -
 
 if [[ "$PLATFORM" == "openshift" ]]; then
   # allow pods with conjur-cluster serviceaccount to run as root

--- a/kubernetes/conjur-authenticator-role.yaml
+++ b/kubernetes/conjur-authenticator-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1 # TODO: change this to match your k8s version
 kind: ClusterRole
 metadata:
-  name: conjur-authenticator
+  name: conjur-authenticator-{{ CONJUR_NAMESPACE_NAME }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods", "serviceaccounts"]

--- a/openshift/conjur-authenticator-role.yaml
+++ b/openshift/conjur-authenticator-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ClusterRole
 metadata:
-  name: conjur-authenticator
+  name: conjur-authenticator-{{ CONJUR_NAMESPACE_NAME }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods", "serviceaccounts"]


### PR DESCRIPTION
To avoid collisions in conjur-authenticator ClusterRole deletion, the
namespace will be appended to the ClusterRole


The current `5.0-stable` appliance image is broken for k8s, so this was built pinned to `5.1.2` and had a green build.