### PR TITLE
Update kubectl used in test scripts

### DIFF
--- a/secrets.yml
+++ b/secrets.yml
@@ -2,7 +2,7 @@ GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
 GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
 GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
 GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
-KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.7.6/bin/linux/amd64/kubectl
+KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
 
 openshift37:
   K8S_VERSION: '1.7'


### PR DESCRIPTION
The cluster was upgraded to v1.9.7, and this PR updates kubectl used in the
tests to the same version.