### PR TITLE
Fixed issues with DEPLOY_MASTER_CLUSTER not being checked properly

### DIFF
--- a/start
+++ b/start
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# XXX: Prevents `set -u` from breaking out of the checks if this
+#      variable is not defined
+export DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"
+
 if [[ $PLATFORM == openshift ]]; then
   oc login -u $OSHIFT_CLUSTER_ADMIN_USERNAME
 fi


### PR DESCRIPTION
If this value is not defaulted, there's a high risk that it will fail
since the new env files do not have it set by default.