### PR TITLE
Add readiness probes to follower manifests

### DIFF
--- a/kubernetes/conjur-follower.yaml
+++ b/kubernetes/conjur-follower.yaml
@@ -44,5 +44,12 @@ spec:
           name: pg-main
         - containerPort: 5433
           name: pg-audit
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 443
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
       imagePullSecrets:
         - name: dockerpullsecret

--- a/openshift/conjur-follower.yaml
+++ b/openshift/conjur-follower.yaml
@@ -46,3 +46,10 @@ spec:
           name: pg-main
         - containerPort: 5433
           name: pg-audit
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 443
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          timeoutSeconds: 1


### PR DESCRIPTION
Update the manifests to include readiness probes for the Conjur followers

Tested in OpenShift 3.9

Connected to #41 