### PR TITLE
Remove buggy cluster info printing when deploying follower

### DIFF
--- a/start
+++ b/start
@@ -29,4 +29,7 @@ if [[ "${DEPLOY_MASTER_CLUSTER}" = "true" ]]; then
 fi
 
 ./8_configure_followers.sh
-./9_print_cluster_info.sh
+
+if [[ "${DEPLOY_MASTER_CLUSTER}" = "true" ]]; then
+  ./9_print_cluster_info.sh
+fi


### PR DESCRIPTION
This script is only applicable to master cluster deployment so it should
not execute otherwise.