### PR TITLE
Reverted CLI change that hard-coded the CLI version image

### DIFF
--- a/openshift/conjur-cli.yml
+++ b/openshift/conjur-cli.yml
@@ -19,8 +19,8 @@ spec:
       serviceAccountName: conjur-cluster
       containers:
       - name: conjur-cli
-        image: cyberark/conjur-cli:5
-        imagePullPolicy: IfNotPresent
+        image: {{ DOCKER_IMAGE }}
+        imagePullPolicy: {{ IMAGE_PULL_POLICY }}
         command: ["sleep"]
         args: ["infinity"]
       imagePullSecrets:


### PR DESCRIPTION
This change wasn't needed and possibly broke master deployment of the
k8s-conjur-demo.

Connected to: https://github.com/conjurinc/appliance/issues/772