### PR TITLE
Added default value for variable STOP_RUNNING_ENV

### DIFF
--- a/start
+++ b/start
@@ -5,7 +5,7 @@ set -euo pipefail
 #      variable is not defined
 export DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"
 export FOLLOWER_SEED="${FOLLOWER_SEED:-}"
-export STOP_RUNNING_ENV="${STOP_RUNNING_ENV:-true}"
+STOP_RUNNING_ENV="${STOP_RUNNING_ENV:-true}"
 
 
 if [[ $PLATFORM == openshift ]]; then

--- a/start
+++ b/start
@@ -5,6 +5,8 @@ set -euo pipefail
 #      variable is not defined
 export DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"
 export FOLLOWER_SEED="${FOLLOWER_SEED:-}"
+export STOP_RUNNING_ENV="${STOP_RUNNING_ENV:-true}"
+
 
 if [[ $PLATFORM == openshift ]]; then
   oc login -u $OSHIFT_CLUSTER_ADMIN_USERNAME
@@ -12,7 +14,9 @@ fi
 
 ./0_check_dependencies.sh
 
-./stop
+if [[ "${STOP_RUNNING_ENV}" = "true" ]]; then
+    ./stop
+fi
 
 ./1_prepare_conjur_namespace.sh
 ./2_prepare_docker_images.sh


### PR DESCRIPTION
Made the running of the stop script optional
In our documentation we create service accounts in conur namespace before running this scripts so if the namespace is being purged all the service accounts that were created before are deleted