### PR TITLE
Removed addition of IPs to DNS SAN entries on master cluster config

### DIFF
--- a/6_configure_master.sh
+++ b/6_configure_master.sh
@@ -35,18 +35,7 @@ configure_master_pod() {
 
   if [ $PLATFORM = 'openshift' ]; then
     $cli create route passthrough --service=conjur-master
-
     echo "Created passthrough route for conjur-master service."
-
-    conjur_master_route=$($cli get routes | grep conjur-master | awk '{ print $2 }')
-    MASTER_ALTNAMES="$MASTER_ALTNAMES,$conjur_master_route"
-
-    echo "Added conjur-master service route ($conjur_master_route) to Master cert altnames."
-  else
-    conjur_master_service_external_ip="$(kubectl get --no-headers service conjur-master | awk '{print $3 }')"
-    MASTER_ALTNAMES="$MASTER_ALTNAMES,$conjur_master_service_external_ip"
-
-    echo "Added conjur-master service external IP ($conjur_master_service_external_ip) to Master cert altnames."
   fi
 
   # Configure Conjur master server using evoke.


### PR DESCRIPTION
Evoke has removed the ability to add IP entries to certificate SAN
fields since they were already prefixed with `DNS:` and should not have
worked. By doing this, our code here broke since it was stuffing and IP
address into the master altname which should not have worked at all.
This change removes that IP from the altnames to make things work again.