### PR TITLE
Fix missing variable in ./stop script

### DIFF
--- a/stop
+++ b/stop
@@ -4,6 +4,7 @@ set -euo pipefail
 . utils.sh
 
 if [[ $PLATFORM == openshift ]]; then
+  OPENSHIFT_USERNAME="${OPENSHIFT_USERNAME:-$OSHIFT_CLUSTER_ADMIN_USERNAME}"
   $cli login -u $OPENSHIFT_USERNAME
 fi
 


### PR DESCRIPTION
By default, we don't define OPENSHIFT_USERNAME in non-Jenkins
deployments so this variable will fail running of the code. This change
ensures that `./stop` can handle this missing variable just like the
`./start` script.