### PR TITLE
Fix intermittent build failures w/ waiting on pods

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -121,16 +121,17 @@ wait_for_it() {
 
     echo "Waiting for '$@' up to $timeout s"
     for i in $(seq $times_to_run); do
-      eval $@ && echo 'Success!' && break
+      eval $@ > /dev/null && echo 'Success!' && return 0
       echo -n .
       sleep $spacer
     done
 
+    # Last run evaluated. If this fails we return an error exit code to caller
     eval $@
   else
     echo "Waiting for '$@' forever"
 
-    while ! eval $@; do
+    while ! eval $@ > /dev/null; do
       echo -n .
       sleep $spacer
     done


### PR DESCRIPTION
We had transient failures in the timed wait loop when this was called from the conjurdemos/kubernetes-conjur-demo pipeline that was caused by a
wait command that succeeded then failed right after. Now we ensure
that on success we return as soon as we pass the condition.