### PR TITLE
Add encryption key checking and use when starting follower

### DIFF
--- a/8_configure_followers.sh
+++ b/8_configure_followers.sh
@@ -48,12 +48,19 @@ configure_followers() {
 configure_follower() {
   local pod_name=$1
 
+  KEYS_COMMAND=""
+
   printf "Configuring follower %s...\n" $pod_name
 
   copy_file_to_container $FOLLOWER_SEED "/tmp/follower-seed.tar" "$pod_name"
 
+  if [ -f "$CONJUR_DATA_KEY" ]; then
+    copy_file_to_container $CONJUR_DATA_KEY "/opt/conjur/etc/conjur-data-key" "$pod_name"
+    KEYS_COMMAND="evoke keys exec -m /opt/conjur/etc/conjur-data-key --"
+  fi
+
   $cli exec $pod_name -- evoke unpack seed /tmp/follower-seed.tar
-  $cli exec $pod_name -- evoke configure follower
+  $cli exec $pod_name -- $KEYS_COMMAND evoke configure follower
 }
 
 delete_follower_seed() {

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ Steps to startup Minishift:
 Ensure that `bootstrap.env` has the `FOLLOWER_SEED` variable set to the seed
 file created [here](#follower-seed) or a URL to the seed service.
 
+If master key encryption is used in the cluster, `CONJUR_DATA_KEY` must be set to the path to a file that contains the
+encryption key to use when configuring the follower.
+
 After verifying this setting, source `./bootstrap.env` and then run `./start` to
 execute the scripts necessary to have the follower deployed in your environment.
 


### PR DESCRIPTION
This allows clusters that are using master key encryption to optionally provide the key file to be used by the follower.  