### PR TITLE
ClusterRole is deleted on cleanup

### DIFF
--- a/stop
+++ b/stop
@@ -23,4 +23,7 @@ if has_namespace $CONJUR_NAMESPACE_NAME; then
   echo ""
 fi
 
+echo "Deleting cluster role"
+$cli delete --ignore-not-found clusterrole conjur-authenticator-$CONJUR_NAMESPACE_NAME
+
 echo "Conjur environment purged."


### PR DESCRIPTION
The CI pipeline currently leaves the cluster role intact after cleaning up,
leaving unused cluster roles dangling in the platform environment. This change
ensures that they are cleaned up after the test run.