### PR TITLE
Fix issues with follower deployments variable evaluation

### DIFF
--- a/8_configure_followers.sh
+++ b/8_configure_followers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 set -euo pipefail
 
 . utils.sh
@@ -54,12 +54,15 @@ configure_follower() {
 
   copy_file_to_container $FOLLOWER_SEED "/tmp/follower-seed.tar" "$pod_name"
 
-  if [ -f "$CONJUR_DATA_KEY" ]; then
+  if [ -f "${CONJUR_DATA_KEY:-}" ]; then
     copy_file_to_container $CONJUR_DATA_KEY "/opt/conjur/etc/conjur-data-key" "$pod_name"
     KEYS_COMMAND="evoke keys exec -m /opt/conjur/etc/conjur-data-key --"
   fi
 
+  echo "Unpacking seed..."
   $cli exec $pod_name -- evoke unpack seed /tmp/follower-seed.tar
+
+  echo "Configuring follower with evoke..."
   $cli exec $pod_name -- $KEYS_COMMAND evoke configure follower
 }
 


### PR DESCRIPTION
Old code in some cases would get into configuration of the follower
without a CONJUR_DATA_KEY defined and bash would consider that to be an
error and return from the function without configuring the follower.
This change ensures that we go through the follower configuration even
if that variable is undefined (which is a common case in follower
deployment).

**Note: This fix does not fully solve the problem but it does get us to the next one!**

Connected to #80 
Connected to #76