### PR TITLE
WIP - Set Conjur log level in DAP in case it was provided

### DIFF
--- a/6_configure_master.sh
+++ b/6_configure_master.sh
@@ -48,10 +48,13 @@ configure_master_pod() {
      $CONJUR_ACCOUNT
   echo "Master pod configured."
 
-  # Set Conjur log level in case it was provided
+  # Set Conjur log level in master & follower in case it was provided
   if [ -n "${CONJUR_LOG_LEVEL:-}" ]; then
     echo "Setting CONJUR_LOG_LEVEL to $CONJUR_LOG_LEVEL"
     $cli exec $master_pod_name -- evoke variable set CONJUR_LOG_LEVEL $CONJUR_LOG_LEVEL
+
+    follower_pod_name=$(get_follower_pod_name)
+    $cli exec $follower_pod_name -- evoke variable set CONJUR_LOG_LEVEL $CONJUR_LOG_LEVEL
   fi
 
   # Write standby seed to persistent storage if /opt/conjur/data is mounted

--- a/6_configure_master.sh
+++ b/6_configure_master.sh
@@ -48,6 +48,12 @@ configure_master_pod() {
      $CONJUR_ACCOUNT
   echo "Master pod configured."
 
+  # Set Conjur log level in case it was provided
+  if [ -n "${CONJUR_LOG_LEVEL:-}" ]; then
+    echo "Setting CONJUR_LOG_LEVEL to $CONJUR_LOG_LEVEL"
+    $cli exec $master_pod_name -- evoke variable set CONJUR_LOG_LEVEL $CONJUR_LOG_LEVEL
+  fi
+
   # Write standby seed to persistent storage if /opt/conjur/data is mounted
   if $cli exec $master_pod_name -- ls /opt/conjur/data &>/dev/null; then
     $cli exec $master_pod_name -- bash -c "evoke seed standby > /opt/conjur/data/standby-seed.tar"

--- a/utils.sh
+++ b/utils.sh
@@ -94,6 +94,11 @@ get_conjur_cli_pod_name() {
   echo $pod_list | awk '{print $1}'
 }
 
+get_follower_pod_name() {
+  pod_list=$($cli get pods -l role=follower --no-headers | awk '{ print $1 }')
+  echo $pod_list | awk '{print $1}'
+}
+
 set_namespace() {
   if [[ $# != 1 ]]; then
     printf "Error in %s/%s - expecting 1 arg.\n" $(pwd) $0


### PR DESCRIPTION
This PR lets consumers of `kubernetes-conjur-deploy` to set the log level of the DAP server by setting the `CONJUR_LOG_LEVEL` environment variable before running the `start` script.