### PR TITLE
Load RoleBinding for service-account conjur-cluster

### DIFF
--- a/4_deploy_conjur_followers.sh
+++ b/4_deploy_conjur_followers.sh
@@ -80,7 +80,10 @@ add_server_certificate_to_configmap() {
 
 enable_conjur_authenticate() {
   if [[ "${FOLLOWER_SEED}" =~ ^http[s]?:// ]]; then
-    announce "Creating conjur service account and authenticator role binding."
+    announce "Creating conjur-cluster service account and authenticator role binding."
+
+    sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" "./$PLATFORM/conjur-cluster-service-account.yaml" |
+        $cli create -f -
 
     sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" "./$PLATFORM/conjur-authenticator-role-binding.yaml" |
         $cli create -f -

--- a/kubernetes/conjur-authenticator-role-binding.yaml
+++ b/kubernetes/conjur-authenticator-role-binding.yaml
@@ -1,17 +1,11 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: conjur
-  namespace: {{ CONJUR_NAMESPACE_NAME }}
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}
 subjects:
   - kind: ServiceAccount
-    name: conjur
+    name: conjur-cluster
     namespace: {{ CONJUR_NAMESPACE_NAME }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/conjur-cluster-service-account.yaml
+++ b/kubernetes/conjur-cluster-service-account.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: conjur-cluster
+  namespace: {{ CONJUR_NAMESPACE_NAME }}

--- a/openshift/conjur-authenticator-role-binding.yaml
+++ b/openshift/conjur-authenticator-role-binding.yaml
@@ -1,17 +1,11 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: conjur
-  namespace: {{ CONJUR_NAMESPACE_NAME }}
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}
 subjects:
   - kind: ServiceAccount
-    name: conjur
+    name: conjur-cluster
     namespace: {{ CONJUR_NAMESPACE_NAME }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/openshift/conjur-cluster-service-account.yaml
+++ b/openshift/conjur-cluster-service-account.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: conjur-cluster
+  namespace: {{ CONJUR_NAMESPACE_NAME }}


### PR DESCRIPTION
Edit: do we even need to load this rolebinding? check this and remove if not. 

The RoleBinding was for service-account "conjur" while the service
account that is used in the deployment is "conjur-cluster". This
made the consumers of this project - `kubernetes-conjur-demo` &
`cyberark-secrets-provider` to load the RoleBinding by themselves
while it should be their responsibility.

The ServiceAccount that was created - "conjur" is actually not used in the environment.