### PR TITLE
Reduce noise from building test image

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -20,7 +20,7 @@ RUN wget -O /usr/local/bin/kubectl ${KUBECTL_CLI_URL:-https://storage.googleapis
 # Install OpenShift oc CLI
 ARG OPENSHIFT_CLI_URL
 RUN mkdir -p ocbin && \
-    wget -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz} && \
+    wget --no-verbose -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz} && \
     tar xvf oc.tar.gz --strip-components=1 -C ocbin && \
     mv ocbin/oc /usr/local/bin/oc && \
     rm -rf ocbin oc.tar.gz


### PR DESCRIPTION
`wget` was flooding the output with progress update from the `oc` tool
download. We now squelch the output of it with `--no-verbose` flag.