### PR TITLE
Reduce noise from downloading `kubectl` in test images

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -14,7 +14,7 @@ RUN apt-get update -y && \
 
 # Install kubectl CLI
 ARG KUBECTL_CLI_URL
-RUN wget -O /usr/local/bin/kubectl ${KUBECTL_CLI_URL:-https://storage.googleapis.com/kubernetes-release/release/v1.7.6/bin/linux/amd64/kubectl} && \
+RUN wget --no-verbose -O /usr/local/bin/kubectl ${KUBECTL_CLI_URL:-https://storage.googleapis.com/kubernetes-release/release/v1.7.6/bin/linux/amd64/kubectl} && \
     chmod +x /usr/local/bin/kubectl
 
 # Install OpenShift oc CLI


### PR DESCRIPTION
This should reduce our logs significantly even more as we won't dump
out the progress updates to jenkins logs.