### PR TITLE
Add host mount via emptydir volumes for postgres, conjur and nginx logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,14 @@ Steps to startup Minishift:
 Ensure that `bootstrap.env` has the `FOLLOWER_SEED` variable set to the seed
 file created [here](#follower-seed) or a URL to the seed service.
 
-If master key encryption is used in the cluster, `CONJUR_DATA_KEY` must be set to the path to a file that contains the
-encryption key to use when configuring the follower.
+If master key encryption is used in the cluster, `CONJUR_DATA_KEY` must be set to
+the path to a file that contains the encryption key to use when configuring the
+follower.
+
+By default, the follower will store all data within the container.  If
+`FOLLOWER_USE_VOLUMES` is set to `true`, the follower will use host volumes (not
+persistent volumes) for `/var/log/conjur`, `/var/log/nginx` and
+`/var/lib/postgresql/9.4`.
 
 After verifying this setting, source `./bootstrap.env` and then run `./start` to
 execute the scripts necessary to have the follower deployed in your environment.

--- a/kubernetes/conjur-follower.yaml
+++ b/kubernetes/conjur-follower.yaml
@@ -36,6 +36,7 @@ spec:
       - name: conjur-token
         emptyDir:
           medium: Memory
+      {{ FOLLOWER_VOLUMES }}
 
       initContainers:
       - name: authenticator
@@ -109,5 +110,6 @@ spec:
           - name: seedfile
             mountPath: /tmp/seedfile
             readOnly: true
+          {{ FOLLOWER_VOLUME_MOUNTS }}
       imagePullSecrets:
         - name: dockerpullsecret

--- a/openshift/conjur-follower.yaml
+++ b/openshift/conjur-follower.yaml
@@ -36,6 +36,7 @@ spec:
       - name: conjur-token
         emptyDir:
           medium: Memory
+      {{ FOLLOWER_VOLUMES }}
 
       initContainers:
       - name: authenticator
@@ -109,5 +110,6 @@ spec:
           - name: seedfile
             mountPath: /tmp/seedfile
             readOnly: true
+          {{ FOLLOWER_VOLUME_MOUNTS }}
       imagePullSecrets:
         - name: dockerpullsecret


### PR DESCRIPTION
In OpenShift 3.9, ephemeral disk storage cannot be configured per-pod or per-container, only in the global docker daemon settings, with a default of 10GB.  In OpenShift 3.10 and 3.11, this feature is experimental and not enabled by default.  Because of the potentially large size of log audit and nginx log file sizes, this uses the emptydir host volume mounts to prevent the container from running out of storage under loads typically seen during testing or longer running followers.