### PR TITLE
Converted most non-specific CLI usages to kubectl

### DIFF
--- a/1_prepare_conjur_namespace.sh
+++ b/1_prepare_conjur_namespace.sh
@@ -49,12 +49,12 @@ create_service_account() {
     if has_serviceaccount $CONJUR_SERVICEACCOUNT_NAME; then
         echo "Service account '$CONJUR_SERVICEACCOUNT_NAME' exists, not going to create it."
     else
-        $cli create serviceaccount $CONJUR_SERVICEACCOUNT_NAME -n $CONJUR_NAMESPACE_NAME
+        kubectl create serviceaccount $CONJUR_SERVICEACCOUNT_NAME -n $CONJUR_NAMESPACE_NAME
     fi
 }
 
 create_cluster_role() {
-  $cli delete --ignore-not-found clusterrole conjur-authenticator-$CONJUR_NAMESPACE_NAME
+  kubectl delete --ignore-not-found clusterrole conjur-authenticator-$CONJUR_NAMESPACE_NAME
 
   sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" ./$PLATFORM/conjur-authenticator-role.yaml |
     $cli apply -f -

--- a/4_deploy_conjur_followers.sh
+++ b/4_deploy_conjur_followers.sh
@@ -24,9 +24,9 @@ docker_login() {
     if ! [ "${DOCKER_EMAIL}" = "" ]; then
       announce "Creating image pull secret."
 
-      $cli delete --ignore-not-found secret dockerpullsecret
+      kubectl delete --ignore-not-found secret dockerpullsecret
 
-      $cli create secret docker-registry dockerpullsecret \
+      kubectl create secret docker-registry dockerpullsecret \
            --docker-server=$DOCKER_REGISTRY_URL \
            --docker-username=$DOCKER_USERNAME \
            --docker-password=$DOCKER_PASSWORD \
@@ -35,15 +35,15 @@ docker_login() {
   elif [ $PLATFORM = 'openshift' ]; then
     announce "Creating image pull secret."
 
-    $cli delete --ignore-not-found secrets dockerpullsecret
+    kubectl delete --ignore-not-found secrets dockerpullsecret
 
-    $cli secrets new-dockercfg dockerpullsecret \
+    oc secrets new-dockercfg dockerpullsecret \
          --docker-server=${DOCKER_REGISTRY_PATH} \
          --docker-username=_ \
-         --docker-password=$($cli whoami -t) \
+         --docker-password=$(oc whoami -t) \
          --docker-email=_
 
-    $cli secrets add serviceaccount/conjur-cluster secrets/dockerpullsecret --for=pull
+    oc secrets add serviceaccount/conjur-cluster secrets/dockerpullsecret --for=pull
   fi
 }
 
@@ -71,10 +71,10 @@ add_server_certificate_to_configmap() {
   ./_save_server_cert.sh $SERVER_CERTIFICATE
   if [[ -f "${SERVER_CERTIFICATE}" ]]; then
     announce "Saving server certificate to configmap."
-    $cli create configmap server-certificate --from-file=ssl-certificate=<(cat "${SERVER_CERTIFICATE}")
+    kubectl create configmap server-certificate --from-file=ssl-certificate=<(cat "${SERVER_CERTIFICATE}")
   else
     echo "WARN: no server certificate was provided saving empty configmap"
-    $cli create configmap server-certificate --from-file=ssl-certificate=<(echo "")
+    kubectl create configmap server-certificate --from-file=ssl-certificate=<(echo "")
   fi
 }
 

--- a/6_configure_master.sh
+++ b/6_configure_master.sh
@@ -19,27 +19,27 @@ configure_master_pod() {
 
   if [ $CONJUR_VERSION = '4' ]; then
     # Move database to persistent storage if /opt/conjur/dbdata is mounted
-    if $cli exec $master_pod_name -- ls /opt/conjur/dbdata &>/dev/null; then
-      if ! $cli exec $master_pod_name -- ls /opt/conjur/dbdata/9.3 &>/dev/null; then
+    if kubectl exec $master_pod_name -- ls /opt/conjur/dbdata &>/dev/null; then
+      if ! kubectl exec $master_pod_name -- ls /opt/conjur/dbdata/9.3 &>/dev/null; then
         # No existing data found, set up database symlink
-        $cli exec $master_pod_name -- mv /var/lib/postgresql/9.3 /opt/conjur/dbdata/
-        $cli exec $master_pod_name -- ln -sf /opt/conjur/dbdata/9.3 /var/lib/postgresql/9.3
+        kubectl exec $master_pod_name -- mv /var/lib/postgresql/9.3 /opt/conjur/dbdata/
+        kubectl exec $master_pod_name -- ln -sf /opt/conjur/dbdata/9.3 /var/lib/postgresql/9.3
         echo "Master database moved to persistent storage"
       fi
     fi
   fi
 
-  $cli label --overwrite pod $master_pod_name role=master
+  kubectl label --overwrite pod $master_pod_name role=master
 
   MASTER_ALTNAMES="localhost,conjur-master"
 
   if [ $PLATFORM = 'openshift' ]; then
-    $cli create route passthrough --service=conjur-master
+    oc create route passthrough --service=conjur-master
     echo "Created passthrough route for conjur-master service."
   fi
 
   # Configure Conjur master server using evoke.
-  $cli exec $master_pod_name -- evoke configure master \
+  kubectl exec $master_pod_name -- evoke configure master \
      --accept-eula \
      -h conjur-master.$CONJUR_NAMESPACE_NAME.svc.cluster.local \
      --master-altnames "$MASTER_ALTNAMES" \
@@ -51,8 +51,8 @@ configure_master_pod() {
   set_conjur_pod_log_level $master_pod_name
 
   # Write standby seed to persistent storage if /opt/conjur/data is mounted
-  if $cli exec $master_pod_name -- ls /opt/conjur/data &>/dev/null; then
-    $cli exec $master_pod_name -- bash -c "evoke seed standby > /opt/conjur/data/standby-seed.tar"
+  if kubectl exec $master_pod_name -- ls /opt/conjur/data &>/dev/null; then
+    kubectl exec $master_pod_name -- bash -c "evoke seed standby > /opt/conjur/data/standby-seed.tar"
     echo "Seed created in persistent storage."
   fi
 }
@@ -66,7 +66,7 @@ wait_for_master() {
   # Wait for 10 successful connections in a row
   local COUNTER=0
   while [  $COUNTER -lt 10 ]; do
-      local response=$($cli exec $conjur_cli_pod -- bash -c "curl -k --silent --head $conjur_url/health")
+      local response=$(kubectl exec $conjur_cli_pod -- bash -c "curl -k --silent --head $conjur_url/health")
       if [ -z "$(echo $response | grep "Conjur-Health: OK")" ]; then
         sleep 5
         COUNTER=0
@@ -86,13 +86,13 @@ configure_cli_pod() {
   local conjur_cli_pod=$(get_conjur_cli_pod_name)
 
   if [ $CONJUR_VERSION = '4' ]; then
-    $cli exec $conjur_cli_pod -- bash -c "yes yes | conjur init -a $CONJUR_ACCOUNT -h $conjur_url"
-    $cli exec $conjur_cli_pod -- conjur plugin install policy
+    kubectl exec $conjur_cli_pod -- bash -c "yes yes | conjur init -a $CONJUR_ACCOUNT -h $conjur_url"
+    kubectl exec $conjur_cli_pod -- conjur plugin install policy
   elif [ $CONJUR_VERSION = '5' ]; then
-    $cli exec $conjur_cli_pod -- bash -c "yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url"
+    kubectl exec $conjur_cli_pod -- bash -c "yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url"
   fi
 
-  $cli exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
+  kubectl exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
 }
 
 main $@

--- a/8_configure_followers.sh
+++ b/8_configure_followers.sh
@@ -32,11 +32,11 @@ prepare_follower_seed() {
 
   FOLLOWER_SEED="./$seed_dir/follower-seed.tar"
 
-  $cli exec $master_pod_name evoke seed follower conjur-follower > $FOLLOWER_SEED
+  kubectl exec $master_pod_name evoke seed follower conjur-follower > $FOLLOWER_SEED
 }
 
 configure_followers() {
-  pod_list=$($cli get pods -l role=follower --no-headers | awk '{ print $1 }')
+  pod_list=$(kubectl get pods -l role=follower --no-headers | awk '{ print $1 }')
 
   for pod_name in $pod_list; do
     configure_follower $pod_name &
@@ -60,10 +60,10 @@ configure_follower() {
   fi
 
   echo "Unpacking seed..."
-  $cli exec $pod_name -- evoke unpack seed /tmp/follower-seed.tar
+  kubectl exec $pod_name -- evoke unpack seed /tmp/follower-seed.tar
 
   echo "Configuring follower with evoke..."
-  $cli exec $pod_name -- $KEYS_COMMAND evoke configure follower
+  kubectl exec $pod_name -- $KEYS_COMMAND evoke configure follower
 }
 
 delete_follower_seed() {

--- a/9_print_cluster_info.sh
+++ b/9_print_cluster_info.sh
@@ -18,7 +18,7 @@ print_cluster_info() {
       ui_url="https://$(get_master_service_ip)"
     fi
   elif [ $PLATFORM = 'openshift' ]; then
-    conjur_master_route=$($cli get routes | grep conjur-master | awk '{ print $2 }')
+    conjur_master_route=$(oc get routes | grep conjur-master | awk '{ print $2 }')
     ui_url="https://$conjur_master_route"
   fi
 

--- a/exec-into-cli.sh
+++ b/exec-into-cli.sh
@@ -2,5 +2,5 @@
 . ./utils.sh
 set_namespace $CONJUR_NAMESPACE_NAME
 conjur_cli_pod=$(get_conjur_cli_pod_name)
-$cli exec -it $conjur_cli_pod -- bash
+kubectl exec -it $conjur_cli_pod -- bash
 set_namespace $TEST_APP_NAMESPACE_NAME

--- a/relaunch_master.sh
+++ b/relaunch_master.sh
@@ -7,26 +7,26 @@ set_namespace $CONJUR_NAMESPACE_NAME
 
 master_pod_name=$(get_master_pod_name)
 
-$cli delete pod $master_pod_name
+kubectl delete pod $master_pod_name
 
 echo "Master pod deleted."
 
 wait_for_node $master_pod_name
 
-$cli exec $master_pod_name -- rm -rf /var/lib/postgresql/9.3
-$cli exec $master_pod_name -- ln -sf /opt/conjur/dbdata/9.3 /var/lib/postgresql/9.3
-# $cli exec $master_pod_name -- chown -h postgres:postgres /var/lib/postgresql/9.3/main
+kubectl exec $master_pod_name -- rm -rf /var/lib/postgresql/9.3
+kubectl exec $master_pod_name -- ln -sf /opt/conjur/dbdata/9.3 /var/lib/postgresql/9.3
+# kubectl exec $master_pod_name -- chown -h postgres:postgres /var/lib/postgresql/9.3/main
 
 echo "Master database recovered."
 
-$cli exec $master_pod_name -- cp /opt/conjur/data/standby-seed.tar /opt/conjur/data/standby-seed.tar-bkup
-$cli exec $master_pod_name -- evoke unpack seed /opt/conjur/data/standby-seed.tar
-$cli exec $master_pod_name -- cp /opt/conjur/data/standby-seed.tar-bkup /opt/conjur/data/standby-seed.tar
-$cli exec $master_pod_name -- rm /etc/chef/solo.json
+kubectl exec $master_pod_name -- cp /opt/conjur/data/standby-seed.tar /opt/conjur/data/standby-seed.tar-bkup
+kubectl exec $master_pod_name -- evoke unpack seed /opt/conjur/data/standby-seed.tar
+kubectl exec $master_pod_name -- cp /opt/conjur/data/standby-seed.tar-bkup /opt/conjur/data/standby-seed.tar
+kubectl exec $master_pod_name -- rm /etc/chef/solo.json
 
 echo "Master configuration recovered."
 
-$cli label --overwrite pod $master_pod_name role=master
+kubectl label --overwrite pod $master_pod_name role=master
 
 master_altnames="localhost,conjur-master.$CONJUR_NAMESPACE_NAME.svc.cluster.local"
 if [ $PLATFORM = 'openshift' ]; then
@@ -34,7 +34,7 @@ if [ $PLATFORM = 'openshift' ]; then
   master_altnames="$master_altnames,$conjur_master_route"
 fi
 
-$cli exec $master_pod_name -- evoke configure master \
+kubectl exec $master_pod_name -- evoke configure master \
    --accept-eula \
    -h conjur-master \
    --master-altnames $master_altnames \
@@ -47,7 +47,7 @@ echo "Master pod configured."
 set_conjur_pod_log_level $master_pod_name
 
 if $cli get statefulset &>/dev/null && [[ $PLATFORM != openshift ]]; then  # this returns non-0 if platform doesn't support statefulset
-  $cli exec haproxy-conjur-master -- kill -s HUP 1  # haproxy runs as PID 1, see Reloading Config here: https://hub.docker.com/_/haproxy/
+  kubectl exec haproxy-conjur-master -- kill -s HUP 1  # haproxy runs as PID 1, see Reloading Config here: https://hub.docker.com/_/haproxy/
   echo 'HAProxy restarted'
 else
   haproxy/update_haproxy.sh haproxy-conjur-master  # non-statefulset configuration uses IPs, needs updated
@@ -58,14 +58,14 @@ sleep 5
 
 echo "Reconfiguring standbys"
 
-standby_pods=$($cli get pods -l role=standby --no-headers | awk '{ print $1 }')
+standby_pods=$(kubectl get pods -l role=standby --no-headers | awk '{ print $1 }')
 for pod_name in $standby_pods; do
-  $cli label --overwrite pod $pod_name role=unset
-  $cli exec $pod_name -- rm -f /etc/chef/solo.json
+  kubectl label --overwrite pod $pod_name role=unset
+  kubectl exec $pod_name -- rm -f /etc/chef/solo.json
 done
 
 ./6_configure_standbys.sh
 
-$cli exec $master_pod_name -- curl -s localhost/health | tee "output/$PLATFORM-relaunch-health.json"
+kubectl exec $master_pod_name -- curl -s localhost/health | tee "output/$PLATFORM-relaunch-health.json"
 
 ./8_print_cluster_info.sh

--- a/stop
+++ b/stop
@@ -5,13 +5,13 @@ set -euo pipefail
 
 if [[ $PLATFORM == openshift ]]; then
   OPENSHIFT_USERNAME="${OPENSHIFT_USERNAME:-$OSHIFT_CLUSTER_ADMIN_USERNAME}"
-  $cli login -u $OPENSHIFT_USERNAME
+  oc login -u $OPENSHIFT_USERNAME
 fi
 
 set_namespace default
 
 if has_namespace $CONJUR_NAMESPACE_NAME; then
-  $cli delete namespace $CONJUR_NAMESPACE_NAME
+  kubectl delete namespace $CONJUR_NAMESPACE_NAME
 
   printf "Waiting for $CONJUR_NAMESPACE_NAME namespace deletion to complete"
 
@@ -24,6 +24,6 @@ if has_namespace $CONJUR_NAMESPACE_NAME; then
 fi
 
 echo "Deleting cluster role"
-$cli delete --ignore-not-found clusterrole conjur-authenticator-$CONJUR_NAMESPACE_NAME
+kubectl delete --ignore-not-found clusterrole conjur-authenticator-$CONJUR_NAMESPACE_NAME
 
 echo "Conjur environment purged."


### PR DESCRIPTION
There is no need for most of these tasks to use OC specifically as
almost everything can be done with kubectl OOTB. Those things that do
not work on kubectl are also now changed from generic `$cli` to `oc`.

Note: there is still work to be done here though as none of the `$cli create`
usages have been converted yet.