### PR TITLE
Move common Summon vars into common section

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
         }*/
         stage('Test v5 on GKE') {
           steps {
-            sh 'summon ./test.sh gke 5'
+            sh 'summon --environment kubernetes ./test.sh gke 5'
           }
         }
         stage('Test on OpenShift 3.9 in AWS') {

--- a/secrets.yml
+++ b/secrets.yml
@@ -1,8 +1,9 @@
-GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
-GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
-GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
-GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
-KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
+kubernetes:
+  GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
+  GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
+  GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
+  GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
+  KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
 
 openshift39:
   K8S_VERSION: '1.9'


### PR DESCRIPTION
Somewhere between Summon v0.6.6 and Summon v0.8.0 it became a requirement
that Summon vars **must** either be in a specific environment **or** in a `common`
section when using Summon environments.

This commit updates the secrets.yml for this project so that it conforms with this new
standard, to facilitate bumping the Summon version in our pipelines.