### PR TITLE
Updates K8s API versions to v1 from v1beta1

### DIFF
--- a/kubernetes/conjur-authenticator-role.yaml
+++ b/kubernetes/conjur-authenticator-role.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1 # TODO: change this to match your k8s version
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: conjur-authenticator-{{ CONJUR_NAMESPACE_NAME }}

--- a/kubernetes/conjur-cli.yml
+++ b/kubernetes/conjur-cli.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: conjur-cli

--- a/kubernetes/conjur-cluster-stateful.yaml
+++ b/kubernetes/conjur-cluster-stateful.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     app: conjur-node
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/kubernetes/conjur-cluster.yaml
+++ b/kubernetes/conjur-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kubernetes/conjur-follower.yaml
+++ b/kubernetes/conjur-follower.yaml
@@ -18,14 +18,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: conjur-follower
+  labels:
+    app: conjur-follower
 spec:
   replicas: {{ CONJUR_FOLLOWER_COUNT }}
+  selector:
+    matchLabels:
+      app: conjur-follower
   template:
     metadata:
       labels:
         app: conjur-follower
-        name: conjur-follower
-        role: follower
     spec:
       serviceAccountName: conjur-cluster
 

--- a/kubernetes/conjur-follower.yaml
+++ b/kubernetes/conjur-follower.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     app: conjur-follower
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: conjur-follower

--- a/openshift/conjur-cli.yml
+++ b/openshift/conjur-cli.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: conjur-cli

--- a/openshift/conjur-cluster-stateful.yaml
+++ b/openshift/conjur-cluster-stateful.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     app: conjur-node
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/openshift/conjur-cluster.yaml
+++ b/openshift/conjur-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/openshift/conjur-follower.yaml
+++ b/openshift/conjur-follower.yaml
@@ -18,14 +18,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: conjur-follower
+  labels:
+    app: conjur-follower
 spec:
   replicas: {{ CONJUR_FOLLOWER_COUNT }}
+  selector:
+    matchLabels:
+      app: conjur-follower
   template:
     metadata:
       labels:
         app: conjur-follower
-        name: conjur-follower
-        role: follower
     spec:
       serviceAccountName: conjur-cluster
 

--- a/openshift/conjur-follower.yaml
+++ b/openshift/conjur-follower.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     app: conjur-follower
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: conjur-follower


### PR DESCRIPTION
This impacts
- ClusterRole (v1 support in k8s 1.8 -
  https://kubernetes.io/blog/2017/10/using-rbac-generally-available-18/)
- Deployment (officially removed support for v1beta1 in k8s 1.16 -
  https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)
- StatefulSet (officially removed support for v1beta1 in k8s 1.16 -
  https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)