### PR TITLE
Restore role follower label in follower pod templates

### DIFF
--- a/kubernetes/conjur-follower.yaml
+++ b/kubernetes/conjur-follower.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         app: conjur-follower
+        name: conjur-follower
+        role: follower
     spec:
       serviceAccountName: conjur-cluster
 

--- a/openshift/conjur-follower.yaml
+++ b/openshift/conjur-follower.yaml
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         app: conjur-follower
+        name: conjur-follower
+        role: follower
     spec:
       serviceAccountName: conjur-cluster
 


### PR DESCRIPTION
The conjurdemos/kubernetes-conjur-demo repo CI is currently failing on that repo's master. Here's a recent failure:
https://jenkins.conjur.net/job/conjurdemos--kubernetes-conjur-demo/job/master/373/
The console output from one test case shows this error:

```
09:54:10  + ./4_store_conjur_cert.sh
09:54:10  ++++++++++++++++++++++++++++++++++++++
09:54:10
09:54:10  Storing Conjur cert for test app configuration.
09:54:10
09:54:10  ++++++++++++++++++++++++++++++++++++++
09:54:10  Retrieving Conjur certificate.
09:54:10  No resources found.
09:54:11  Value added
09:54:11  Value added
09:54:11  No resources found.
09:54:11  error: expected 'exec POD_NAME COMMAND [ARG1] [ARG2] ... [ARGN]'.
09:54:11  POD_NAME and COMMAND are required arguments for the exec command
09:54:11  See 'oc exec -h' for help and examples.
```

The problem seems to stem from this section of the deploy script 4_store_conjur_cert.sh:

```
if $cli get pods --selector role=follower --no-headers; then
  follower_pod_name=$($cli get pods --selector role=follower --no-headers | awk '{ print $1 }' | head -1)
  ssl_cert=$($cli exec $follower_pod_name -- cat /opt/conjur/etc/ssl/conjur.pem)
else
  echo "Regular follower not found. Trying to assume a decomposed follower..."
  follower_pod_name=$($cli get pods --selector role=decomposed-follower --no-headers | awk '{ print $1 }' | head -1)
  ssl_cert=$($cli exec -c "nginx" $follower_pod_name -- cat /opt/conjur/etc/ssl/cert/tls.crt)
fi
```

Apparently, we need the `role: follower` (and possibly the name: `conjur-follower`) pod template labels added back in for the follower deploy manifests in order to allow the Kubernetes Conjur demo scripts to be able to find the follower based on the role: follower label. It should look like this:

```
 template:
    metadata:
      labels:
        app: conjur-follower
        name: conjur-follower
        role: follower
```

Addresses Issue #105