### PR TITLE
107 increasing conjur timeout

### DIFF
--- a/3_deploy_conjur_master_cluster.sh
+++ b/3_deploy_conjur_master_cluster.sh
@@ -102,22 +102,9 @@ deploy_conjur_cli() {
 }
 
 wait_for_conjur() {
-  announce "Waiting for Conjur pods to launch"
-
-  if [[ $CONJUR_DEPLOYMENT == oss ]]; then
-    echo "Waiting for Conjur pod to launch..."
-    wait_for_it 50 "$cli describe pod conjur-cluster | grep State: | grep -c Running | grep -q 2"
-
-    echo "Waiting for Conjur cli pod to launch..."
-    wait_for_it 50 "$cli describe pod conjur-cli | grep State: | grep -c Running | grep -q 1"
-
-    echo "Waiting for postgres pod to launch..."
-    wait_for_it 50 "$cli describe pod conjur-postgres | grep State: | grep -c Running | grep -q 1"
-  else
-    echo "Waiting for Conjur pods to launch..."
-    conjur_pod_count=${CONJUR_POD_COUNT:-3}
-    wait_for_it 600 "$cli describe po conjur-cluster | grep Status: | grep -c Running | grep -q $conjur_pod_count"
-  fi
+  echo "Waiting for Conjur pods to launch..."
+  conjur_pod_count=${CONJUR_POD_COUNT:-3}
+  wait_for_it 600 "$cli describe po conjur-cluster | grep Status: | grep -c Running | grep -q $conjur_pod_count"
 }
 
 main $@


### PR DESCRIPTION
Increase Conjur pods to launch timeout. It exist already in master and now added to specific tag (deploy-oss-tag) since we are working with this tag on secrets-provider-for-k8s.
This fix suppose to handle 30% of our failures on secrets-provider-for-k8s.
 