### PR TITLE
Update kubectl to latest stable

### DIFF
--- a/secrets.yml
+++ b/secrets.yml
@@ -2,7 +2,7 @@ GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
 GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
 GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
 GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
-KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
+KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
 
 openshift39:
   K8S_VERSION: '1.9'


### PR DESCRIPTION
When the client version is too far behind the server version, the following error can result:

Error from server (NotFound): the server could not find the requested resource
This PR updates the client version to avoid the error.

Since we are working on private branch for secrets-provider-for-k8s need to update here as well. (Master already updated by Hugh)