### PR TITLE
Only support CONJUR_VERSION 4 or 5

### DIFF
--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -19,11 +19,8 @@ if [ "${PLATFORM}" = "openshift" ]; then
   check_env_var "OPENSHIFT_USERNAME"
 fi
 
-# check if CONJUR_VERSION is consistent with CONJUR_APPLIANCE_IMAGE
-appliance_tag=${CONJUR_APPLIANCE_IMAGE//[A-Za-z.]*:/}
-appliance_version=${appliance_tag//[.-][0-9A-Za-z.-]*/}
-if [ "${appliance_version}" != "$CONJUR_VERSION" ]; then
-  echo "ERROR! Your appliance does not match the specified Conjur version."
+if [ "${CONJUR_VERSION}" != "5" ] || [ "${CONJUR_VERSION}" != "4"  ]; then
+  echo "ERROR! CONJUR_VERSION is invalid. CONJUR_VERSION must be 4 or 5"
   exit 1
 fi
 


### PR DESCRIPTION
Conjur version was being retrieved from the image name. This version is arbritary and does not provide much value. Since Conjur is now following Cyberark releases (e.g. 11.x) this version is not correct and the script is failing. This commit will make sure CONJUR_VERSION is set to 4 or 5.