### PR TITLE
113 Removed out any references of Conjur v4 (other than README)

### DIFF
--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -19,14 +19,6 @@ if [ "${PLATFORM}" = "openshift" ]; then
   check_env_var "OPENSHIFT_USERNAME"
 fi
 
-# check if CONJUR_VERSION is consistent with CONJUR_APPLIANCE_IMAGE
-appliance_tag=${CONJUR_APPLIANCE_IMAGE//[A-Za-z.]*:/}
-appliance_version=${appliance_tag//[.-][0-9A-Za-z.-]*/}
-if [ "${appliance_version}" != "$CONJUR_VERSION" ]; then
-  echo "ERROR! Your appliance does not match the specified Conjur version."
-  exit 1
-fi
-
 if [[ "${DEPLOY_MASTER_CLUSTER}" = "true" ]]; then
   check_env_var "CONJUR_VERSION"
   check_env_var "CONJUR_ACCOUNT"

--- a/3_deploy_conjur_master_cluster.sh
+++ b/3_deploy_conjur_master_cluster.sh
@@ -51,23 +51,11 @@ deploy_conjur_master_cluster() {
 
   conjur_appliance_image=$(platform_image "conjur-appliance")
 
-  if [ $CONJUR_VERSION = '4' ]; then
-    if $cli get statefulset &>/dev/null && [[ $PLATFORM != openshift ]]; then  # this returns non-0 if platform doesn't support statefulset
-      conjur_cluster_template="./$PLATFORM/conjur-cluster-stateful.yaml"
-    else
-      conjur_cluster_template="./$PLATFORM/conjur-cluster.yaml"
-    fi
-
-    sed -e "s#{{ CONJUR_APPLIANCE_IMAGE }}#$conjur_appliance_image#g" $conjur_cluster_template |
-      sed -e "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
-      $cli create -f -
-  else
-    sed -e "s#{{ CONJUR_APPLIANCE_IMAGE }}#$conjur_appliance_image#g" "./$PLATFORM/conjur-cluster.yaml" |
-      sed -e "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" |
-      sed -e "s#{{ CONJUR_DATA_KEY }}#$(openssl rand -base64 32)#g" |
-      sed -e "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
-      $cli create -f -
-  fi
+  sed -e "s#{{ CONJUR_APPLIANCE_IMAGE }}#$conjur_appliance_image#g" "./$PLATFORM/conjur-cluster.yaml" |
+    sed -e "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" |
+    sed -e "s#{{ CONJUR_DATA_KEY }}#$(openssl rand -base64 32)#g" |
+    sed -e "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
+    $cli create -f -
 }
 
 deploy_conjur_cli() {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,16 @@ export DEPLOY_MASTER_CLUSTER=true
 ```
 
 You will also need to set a few environment variable that are only used when
-configuring the Conjur master. If you are working with Conjur v4, you will need to set:
-
+configuring the Conjur master. If you are working with Conjur that is not v5,
 ```
-export CONJUR_VERSION=4
+export CONJUR_VERSION=<conjur_version>
 ```
 along with any other changes you might want.
 
 Otherwise, this variable will default to `5`.
+
+_Note: If you are using Conjur v4, please use [v4_support](https://github.com/cyberark/kubernetes-conjur-deploy/tree/v4_support)
+branch of this repo!_
 
 You must also provide an account name and password for the Conjur admin account:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,12 +15,6 @@ pipeline {
   stages {
     stage('Run Scripts') {
       parallel {
-        /*stage('Test v4 on K8S 1.7 in GKE') {
-          steps {
-            sh 'sleep 15'  // sleep 15s to avoid script collisions
-            sh 'summon ./test.sh gke 4'
-          }
-        }*/
         stage('Test v5 on GKE') {
           steps {
             sh 'summon --environment kubernetes ./test.sh gke 5'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ followers to a Kubernetes or OpenShift environment. These scripts can also be
 used to deploy a full cluster with Master and Standbys for testing and demo
 purposes but this is not recommended for a production deployment of Conjur.
 
-**Enterprise Only**. To deploy Conjur OSS, please use the [Conjur OSS helm chart](https://github.com/cyberark/conjur-oss-helm-chart).
+**This repo supports CyberArk DAP v10+**. To deploy Conjur OSS, please use
+the [Conjur OSS helm chart](https://github.com/cyberark/conjur-oss-helm-chart).
 
 ---
 
@@ -26,6 +27,9 @@ Edit the values per instructions below, source the appropriate file and run
 The Conjur appliance image can be loaded with `_load_conjur_tarfile.sh`. The script uses environment variables to locate the tarfile image and the value to use as a tag once it's loaded.
 
 ### Conjur Configuration
+
+_Note: If you are using Conjur v4, please use [v4_support](https://github.com/cyberark/kubernetes-conjur-deploy/tree/v4_support)
+branch of this repo!_
 
 #### Appliance Image
 

--- a/test.sh
+++ b/test.sh
@@ -51,11 +51,8 @@ function setupTestEnvironment() {
 }
 
 function buildDockerImages() {
-  if [[ "$CONJUR_VERSION" == "4" ]]; then
-    export CONJUR_APPLIANCE_IMAGE="registry.tld/conjur-appliance:4.9-stable"
-  else
-    export CONJUR_APPLIANCE_IMAGE="registry.tld/conjur-appliance:5.0-stable"
-  fi
+  export CONJUR_APPLIANCE_IMAGE="registry.tld/conjur-appliance:5.0-stable"
+
   docker pull $CONJUR_APPLIANCE_IMAGE
 
   # Test image w/ kubectl and oc CLIs installed to drive scripts.

--- a/utils.sh
+++ b/utils.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONJUR_VERSION=${CONJUR_VERSION:-$CONJUR_MAJOR_VERSION} # default to CONJUR_MAJOR_VERSION if not set
+CONJUR_VERSION=${CONJUR_VERSION:-5} # default to v5 if not set
 PLATFORM="${PLATFORM:-kubernetes}" # default to kubernetes if not set
 DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"
 FOLLOWER_USE_VOLUMES="${FOLLOWER_USE_VOLUMES:-false}"


### PR DESCRIPTION
Since this repo will almost never be used for v4 deployment, all the
special logic we had for it are rather useless, especially given the
fact that the tests for v4 don't run. This should make our code sturdier
and cleaner.
