### PR TITLE
Add external domain to master altnames

### DIFF
--- a/6_configure_master.sh
+++ b/6_configure_master.sh
@@ -24,6 +24,9 @@ configure_master_pod() {
   if [ $PLATFORM = 'openshift' ]; then
     $cli create route passthrough --service=conjur-master
     echo "Created passthrough route for conjur-master service."
+
+    route_path=$(oc get routes | grep conjur-master | awk '{print $2}')
+    MASTER_ALTNAMES="$MASTER_ALTNAMES,$route_path"
   fi
 
   # Configure Conjur master server using evoke.

--- a/6_configure_master.sh
+++ b/6_configure_master.sh
@@ -22,11 +22,12 @@ configure_master_pod() {
   MASTER_ALTNAMES="localhost,conjur-master"
 
   if [ $PLATFORM = 'openshift' ]; then
-    $cli create route passthrough --service=conjur-master
-    echo "Created passthrough route for conjur-master service."
+    $cli create route passthrough --service=conjur-master-ext
+    echo "Created passthrough route for conjur-master-ext service."
 
-    route_path=$(oc get routes | grep conjur-master | awk '{print $2}')
-    MASTER_ALTNAMES="$MASTER_ALTNAMES,$route_path"
+    # Add OpenShift route name to Master altnames to prevent cert errors
+    master_route=$(oc get routes | grep conjur-master-ext | awk '{print $2}')
+    MASTER_ALTNAMES="$MASTER_ALTNAMES,$master_route"
   fi
 
   # Configure Conjur master server using evoke.


### PR DESCRIPTION
### What does this PR do?

During Master configuration, we create an OpenShift route that exposes the Master outside of the cluster. However, if you attempt to use this route w/ the CLI you will get a certificate error because the route domain is not listed in the Master altnames on the cert.

This PR adds the route domain to the Master cert altnames and also modifies the route to use the `conjur-master-ext` service which was intended to be used to expose the Master externally.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation