### PR TITLE
Emphasize the meaning of STOP_RUNNING_ENV

### DIFF
--- a/bootstrap.env
+++ b/bootstrap.env
@@ -19,6 +19,8 @@ export CONJUR_FOLLOWER_COUNT=[number of follower instances to deploy]
 # optional - if not present its value will default to "host/conjur/authn-k8s/$AUTHENTICATOR_ID/apps/$CONJUR_NAMESPACE_NAME/service_account/conjur-cluster"
 export CONJUR_AUTHN_LOGIN=[ID of the Conjur host that will authenticate with Conjur]
 
+export STOP_RUNNING_ENV=[set to 'true' if the namespace $CONJUR_NAMESPACE_NAME and all of its content should be deleted when the start script is run]
+
 #######
 # OPENSHIFT CONFIG (comment out all lines in this section if not using this platform)
 #######

--- a/start
+++ b/start
@@ -16,6 +16,7 @@ fi
 ./0_check_dependencies.sh
 
 if [[ "${STOP_RUNNING_ENV}" = "true" ]]; then
+    echo "Environment variable STOP_RUNNING_ENV is set to 'true', stopping running env"
     ./stop
 fi
 


### PR DESCRIPTION
The default value of STOP_RUNNING_ENV is set to 'true' so in case a customer
misses it, and has already created resources in their env, it will be deleted
without them noticing.

This commit adds a section to `bootstrap.env` that explains its meaning and also
echos that we are stopping the environment before doing so.