### PR TITLE
Create ClusterRoleBinding as part of namespace preparation

### DIFF
--- a/1_prepare_conjur_namespace.sh
+++ b/1_prepare_conjur_namespace.sh
@@ -13,6 +13,7 @@ main() {
   create_conjur_namespace
   create_service_account
   create_cluster_role
+  create_cluster_role_binding
 
   if [[ "$PLATFORM" == "openshift" ]]; then
     configure_oc_rbac
@@ -58,6 +59,13 @@ create_cluster_role() {
 
   sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" ./$PLATFORM/conjur-authenticator-role.yaml |
     $cli apply -f -
+}
+
+create_cluster_role_binding() {
+  $cli delete --ignore-not-found clusterrolebinding conjur-authenticator-role-binding-$CONJUR_NAMESPACE_NAME
+
+  sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" "./$PLATFORM/conjur-authenticator-role-binding.yaml" |
+    $cli create -f -
 }
 
 configure_oc_rbac() {

--- a/4_deploy_conjur_followers.sh
+++ b/4_deploy_conjur_followers.sh
@@ -12,8 +12,6 @@ main() {
 
   deploy_conjur_followers
 
-  enable_conjur_authenticate
-
   sleep 10
 
   echo "Followers created."
@@ -101,15 +99,6 @@ add_server_certificate_to_configmap() {
   else
     echo "WARN: no server certificate was provided saving empty configmap"
     $cli create configmap server-certificate --from-file=ssl-certificate=<(echo "")
-  fi
-}
-
-enable_conjur_authenticate() {
-  if [[ "${FOLLOWER_SEED}" =~ ^http[s]?:// ]]; then
-    announce "Creating conjur service account and authenticator role binding."
-
-    sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" "./$PLATFORM/conjur-authenticator-role-binding.yaml" |
-        $cli create -f -
   fi
 }
 

--- a/kubernetes/conjur-authenticator-role-binding.yaml
+++ b/kubernetes/conjur-authenticator-role-binding.yaml
@@ -1,17 +1,11 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: conjur
-  namespace: {{ CONJUR_NAMESPACE_NAME }}
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}
 subjects:
   - kind: ServiceAccount
-    name: conjur
+    name: conjur-cluster
     namespace: {{ CONJUR_NAMESPACE_NAME }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/openshift/conjur-authenticator-role-binding.yaml
+++ b/openshift/conjur-authenticator-role-binding.yaml
@@ -1,17 +1,11 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: conjur
-  namespace: {{ CONJUR_NAMESPACE_NAME }}
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}
 subjects:
   - kind: ServiceAccount
-    name: conjur
+    name: conjur-cluster
     namespace: {{ CONJUR_NAMESPACE_NAME }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The ClusterRoleBinding was created only after the followers were deployed
but there's no reason that it will be created then and not right after we
create the ClusterRole.

Furthermore, it was created for a new service-account that was named `conjur`
and was never used. This means that it didn't do anything and the only reason why 
we didn't see issues is that the docs tell customers to do it manually (while there's
no reason they should) and consuming projects (e.g `secrets-provider-for-k8s`, `conjur-authn-k8s-client`)
created the correct ClusterRoleBinding on their own.