### PR TITLE
Set CONJUR_LOG_LEVEL to DAP follower if present

### DIFF
--- a/8_configure_followers.sh
+++ b/8_configure_followers.sh
@@ -64,6 +64,8 @@ configure_follower() {
 
   echo "Configuring follower with evoke..."
   $cli exec $pod_name -- $KEYS_COMMAND evoke configure follower
+
+  set_conjur_pod_log_level $pod_name
 }
 
 delete_follower_seed() {

--- a/utils.sh
+++ b/utils.sh
@@ -166,5 +166,7 @@ set_conjur_pod_log_level() {
   if [ -n "$conjur_log_level" ]; then
     echo "Setting CONJUR_LOG_LEVEL to $conjur_log_level in $pod_name"
     $cli exec $pod_name -- evoke variable set CONJUR_LOG_LEVEL $conjur_log_level
+  else
+    echo "Not setting log level as CONJUR_LOG_LEVEL is not set in the env"
   fi
 }


### PR DESCRIPTION
We are setting the CONJUR_LOG_LEVEL value to the DAP
master and stanby if it's present but we should also do
it for the follower.
