### PR TITLE
WIP: Add logic to support local dev environment

### DIFF
--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -7,12 +7,14 @@ check_env_var "CONJUR_APPLIANCE_IMAGE"
 check_env_var "CONJUR_NAMESPACE_NAME"
 check_env_var "AUTHENTICATOR_ID"
 
-if [ ! is_minienv ]; then
+if [ ! is_minienv ] || [ "${DEV}" = "false" ]; then
   check_env_var "DOCKER_REGISTRY_PATH"
 fi
 
-if [ "${PLATFORM}" = "kubernetes" ] && [ ! is_minienv ]; then
-  check_env_var "DOCKER_REGISTRY_URL"
+if [ "${PLATFORM}" = "kubernetes" ]; then
+  if [ ! is_minienv ] || [ "${DEV}" = "false" ]; then
+    check_env_var "DOCKER_REGISTRY_URL"
+  fi
 fi
 
 if [ "${PLATFORM}" = "openshift" ]; then

--- a/1_prepare_conjur_namespace.sh
+++ b/1_prepare_conjur_namespace.sh
@@ -13,7 +13,7 @@ main() {
   create_conjur_namespace
   create_service_account
   create_cluster_role
-  create_cluster_role_binding
+  create_role_binding
 
   if [[ "$PLATFORM" == "openshift" ]]; then
     configure_oc_rbac
@@ -61,7 +61,7 @@ create_cluster_role() {
     $cli apply -f -
 }
 
-create_cluster_role_binding() {
+create_role_binding() {
   $cli delete --ignore-not-found clusterrolebinding conjur-authenticator-role-binding-$CONJUR_NAMESPACE_NAME
 
   sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" "./$PLATFORM/conjur-authenticator-role-binding.yaml" |

--- a/1_prepare_conjur_namespace.sh
+++ b/1_prepare_conjur_namespace.sh
@@ -62,7 +62,7 @@ create_cluster_role() {
 }
 
 create_role_binding() {
-  $cli delete --ignore-not-found clusterrolebinding conjur-authenticator-role-binding-$CONJUR_NAMESPACE_NAME
+  $cli delete --ignore-not-found rolebinding conjur-authenticator-role-binding-$CONJUR_NAMESPACE_NAME
 
   sed -e "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE_NAME#g" "./$PLATFORM/conjur-authenticator-role-binding.yaml" |
     $cli create -f -

--- a/2_prepare_docker_images.sh
+++ b/2_prepare_docker_images.sh
@@ -27,10 +27,10 @@ prepare_conjur_appliance_image() {
 
   # Try to pull the image if we can
   docker pull $CONJUR_APPLIANCE_IMAGE || true
-
   docker tag $CONJUR_APPLIANCE_IMAGE $conjur_appliance_image
 
-  if ! is_minienv; then
+
+  if [ ! is_minienv ] || [ "${DEV}" = "false" ] ; then
     docker push $conjur_appliance_image
   fi
 }
@@ -44,7 +44,7 @@ prepare_conjur_cli_image() {
   cli_app_image=$(platform_image conjur-cli)
   docker tag conjur-cli:$CONJUR_NAMESPACE_NAME $cli_app_image
 
-  if ! is_minienv; then
+  if [ ! is_minienv ] || [ "${DEV}" = "false" ]; then
     docker push $cli_app_image
   fi
 }
@@ -57,7 +57,7 @@ prepare_seed_fetcher_image() {
   seedfetcher_image=$(platform_image seed-fetcher)
   docker tag $SEEDFETCHER_IMAGE $seedfetcher_image
 
-  if ! is_minienv; then
+  if [ ! is_minienv ] || [ "${DEV}" = "false" ]; then
     docker push $seedfetcher_image
   fi
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,12 +138,12 @@ Docker Desktop provides a convenient way to deploy and develop on Conjur from yo
 
 1. Run `source dev-bootstrap.env`
 
-1. Run `./script.sh`
+1. Run `./start`
 
 ### Helpful hints
 
 By default, 2.0 Gib of memory is allocated to Docker. To successfully deploy a DAP Cluster (Master + Followers + Standbys), 
-you will need to increase this to 4 Gib of memory. 
+you will need to increase this to 6 Gib of memory. 
 
 1. Navigate to Docker preferences
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ To configure the Conjur master to persist data, run these commands in the Conjur
 # evoke seed standby > /opt/conjur/data/standby-seed.tar
 ```
 
-Note that setup is done as part of script [`4_configure_master.sh`](4_configure_master.sh).
+Note that setup is done as part of script [`6_configure_master.sh`](6_configure_master.sh).
 
 ### Restore
 
@@ -128,5 +128,30 @@ to get started with the Conjur CLI.
 
 Visit the Conjur UI URL in your browser and login with the admin credentials to
 access the Conjur UI.
+
+## Deploying Conjur Master and Followers (*Local Dev Environment*)
+
+You can now deploy a local development environment for Kubernetes using [Docker Desktop](https://www.docker.com/products/docker-desktop).
+Docker Desktop provides a convenient way to deploy and develop on Conjur from your local machine. To enable this, perform the following:
+
+1. In `dev-bootstrap.env` uncomment the "LOCAL DEV CONFIG" section and adjust the configurations in `dev-bootstrap.env` as needed
+
+1. Run `source dev-bootstrap.env`
+
+1. Run `./script.sh`
+
+### Helpful hints
+
+By default, 2.0 Gib of memory is allocated to Docker. To successfully deploy a DAP Cluster (Master + Followers + Standbys), 
+you will need to increase this to 4 Gib of memory. 
+
+1. Navigate to Docker preferences
+
+1. Click on "Advanced" and slide the "Memory" bar to 4
+
+Before deploying locally using Docker Desktop, ensure you are in the proper `docker-desktop` context. 
+Otherwise, the deployment will not run successfully.
+
+To switch contexts: `kubectl config use-context docker-desktop`
 
 ---

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ export DOCKER_EMAIL=<your-email>
 
 Please make sure that you are logged in to the registry before deploying.
 
+### Running Kubernetes locally
+
+You can now deploy a local development environment for Kubernetes using [Docker Desktop](https://www.docker.com/products/docker-desktop).
+See our [contributing guide][CONTRIBUTING.md] to learn how!
+
 #### OpenShift
 
 OpenShift users should make sure the [integrated Docker registry](https://docs.okd.io/latest/install_config/registry/deploy_registry_existing_clusters.html)

--- a/dev-bootstrap.env
+++ b/dev-bootstrap.env
@@ -58,6 +58,16 @@ export CONJUR_ADMIN_PASSWORD=ADmin123!!!!
 # export DOCKER_REGISTRY_PATH=<registry-domain>/<additional-pathing>
 
 #######
+# LOCAL DEV CONFIG USING DOCKER DESKTOP (uncomment all lines if using this configuration)
+#######
+# export PLATFORM=kubernetes
+# export DEV=true
+# export DEPLOY_MASTER_CLUSTER=true
+# export STOP_RUNNING_ENV=true
+# export CONJUR_APPLIANCE_IMAGE=registry.tld/conjur-appliance:5.0-stable
+# export CONJUR_ACCOUNT=cucumber
+
+#######
 # MINISHIFT CONFIG (uncomment all lines if using this configuration)
 #######
 # export PLATFORM=openshift

--- a/utils.sh
+++ b/utils.sh
@@ -6,8 +6,9 @@ DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"
 FOLLOWER_USE_VOLUMES="${FOLLOWER_USE_VOLUMES:-false}"
 
 MINI_ENV="${MINI_ENV:-false}"
+DEV="${DEV:-false}"
 
-if [[ "$MINI_ENV" == "true" ]]; then
+if [[ "$MINI_ENV" == "true" || "$DEV" == "true" ]]; then
   IMAGE_PULL_POLICY='Never'
 else
   IMAGE_PULL_POLICY='Always'
@@ -42,7 +43,7 @@ announce() {
 platform_image() {
   if [ $PLATFORM = "openshift" ]; then
     echo "$DOCKER_REGISTRY_PATH/$CONJUR_NAMESPACE_NAME/$1:$CONJUR_NAMESPACE_NAME"
-  elif ! is_minienv; then
+  elif [ ! is_minienv ]  || [ "${DEV}" = "false" ]; then
     echo "$DOCKER_REGISTRY_PATH/$1:$CONJUR_NAMESPACE_NAME"
   else
     echo "$1:$CONJUR_NAMESPACE_NAME"


### PR DESCRIPTION
We are pursuing an effort to build a local dev environment so that instead of pushing to a remote K8s cluster, developers can deploy the cluster locally with Docker desktop
- Add dev checks to block from unnecessary code from running
- Create separate bootstrap.env file for local development

TODO:
- [x] Add documentation for deploying Conjur for local development
- [x] Provide automated scripts for easy deployment with Secrets Provider

Feedback from: https://github.com/cyberark/kubernetes-conjur-deploy/pull/131/files