### PR TITLE
DockerPullSecret: adapt oc 4.X api changes

### DIFF
--- a/4_deploy_conjur_followers.sh
+++ b/4_deploy_conjur_followers.sh
@@ -35,13 +35,13 @@ docker_login() {
 
     $cli delete --ignore-not-found secrets dockerpullsecret
 
-    $cli secrets new-dockercfg dockerpullsecret \
-         --docker-server=${DOCKER_REGISTRY_PATH} \
+    $cli create secret docker-registry dockerpullsecret \
+         --docker-server=$DOCKER_REGISTRY_PATH \
          --docker-username=_ \
          --docker-password=$($cli whoami -t) \
          --docker-email=_
 
-    $cli secrets add serviceaccount/conjur-cluster secrets/dockerpullsecret --for=pull
+    $cli secrets link serviceaccount/conjur-cluster secrets/dockerpullsecret --for=pull
   fi
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR is meant to apply oc cli api changes from version 3.11 to version 4.X in the secrets add section.

### Issue:
No related issue.

### Testing
Tested locally with oc version:
Client Version: 4.4.11
Server Version: 4.3.21
Kubernetes Version: v1.16.2

### Documentation
Old API reference: https://docs.openshift.com/enterprise/3.0/dev_guide/image_pull_secrets.html
New API reference: https://docs.openshift.com/container-platform/4.4/openshift_images/managing_images/using-image-pull-secrets.html