### PR TITLE
Set postgres container imagePullPolicy to Always

### DIFF
--- a/oss/conjur-postgres.yaml
+++ b/oss/conjur-postgres.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: postgres
           image: postgres:9.4
-          imagePullPolicy: {{ IMAGE_PULL_POLICY }}
+          imagePullPolicy: Always
           env:
             - name: POSTGRES_HOST_AUTH_METHOD
               value: password


### PR DESCRIPTION
When running the postgres pod with imagePullPolicy=Never we
get the error `Container image "postgres:9.4" is not present with pull policy of Never`
