### PR TITLE
Add imagePullSecret to OC yamls

### DIFF
--- a/openshift/conjur-cli.yml
+++ b/openshift/conjur-cli.yml
@@ -23,3 +23,5 @@ spec:
         imagePullPolicy: {{ IMAGE_PULL_POLICY }}
         command: ["sleep"]
         args: ["infinity"]
+      imagePullSecrets:
+        - name: dockerpullsecret

--- a/openshift/conjur-cluster-stateful.yaml
+++ b/openshift/conjur-cluster-stateful.yaml
@@ -53,6 +53,8 @@ spec:
           mountPath: /opt/conjur/dbdata
         - name: conjur-data
           mountPath: /opt/conjur/data
+      imagePullSecrets:
+        - name: dockerpullsecret
   volumeClaimTemplates:
   - metadata:
       name: conjur-dbdata

--- a/openshift/conjur-cluster.yaml
+++ b/openshift/conjur-cluster.yaml
@@ -41,3 +41,5 @@ spec:
             path: /health
             port: https
             scheme: HTTPS
+      imagePullSecrets:
+        - name: dockerpullsecret

--- a/openshift/conjur-follower.yaml
+++ b/openshift/conjur-follower.yaml
@@ -116,3 +116,5 @@ spec:
             mountPath: /tmp/seedfile
             readOnly: true
           {{ FOLLOWER_VOLUME_MOUNTS }}
+      imagePullSecrets:
+        - name: dockerpullsecret


### PR DESCRIPTION
### What does this PR do?
The imagePullSecrets were removed in [this PR](https://github.com/cyberark/kubernetes-conjur-deploy/pull/137) but removing this made all the OCP3 builds to fail.