### PR TITLE
Support OC 4.3-FIPS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,11 +40,11 @@ pipeline {
             sh 'summon --environment openshift43 ./test.sh openshift43 5'
           }
         }
-        // stage('Test on OpenShift 4.3-fips in AWS') {
-        //  steps {
-        //    sh 'summon --environment openshift43-fips ./test.sh openshift43-fips 5'
-        //  }
-        // }
+        stage('Test on OpenShift 4.3-fips in AWS') {
+         steps {
+           sh 'summon --environment openshift43-fips ./test.sh openshift43-fips 5'
+         }
+        }
       }
       post { always {
         archiveArtifacts artifacts: 'output/*'

--- a/secrets.yml
+++ b/secrets.yml
@@ -37,10 +37,10 @@ openshift43:
   OPENSHIFT_PASSWORD: !var ci/openshift/4.3/password
   OPENSHIFT_REGISTRY_URL: !var ci/openshift/4.3/registry-url
 
-# openshift43-fips:
-#  K8S_VERSION: '1.16'
-#  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.3/openshift-client-linux.tar.gz
-#  OPENSHIFT_URL: !var dev/openshift/4.3-fips/api-url
-#  OPENSHIFT_USERNAME: !var dev/openshift/4.3-fips/username
-#  OPENSHIFT_PASSWORD: !var dev/openshift/4.3-fips/password
-#  OPENSHIFT_REGISTRY_URL: !var dev/openshift/4.3-fips/registry-url
+openshift43-fips:
+  K8S_VERSION: '1.16'
+  OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.3/openshift-client-linux.tar.gz
+  OPENSHIFT_URL: !var ci/openshift/4.3-fips/api-url
+  OPENSHIFT_USERNAME: !var ci/openshift/4.3-fips/username
+  OPENSHIFT_PASSWORD: !var ci/openshift/4.3-fips/password
+  OPENSHIFT_REGISTRY_URL: !var ci/openshift/4.3-fips/registry-url


### PR DESCRIPTION
When infra publish that the static claster of 4.3-fips is available with variables defined in this secrets.yaml - this build and PR should pass & marged 



### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation