### PR TITLE
Make CONJUR_APPLIANCE_IMAGE tag configurable

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -54,7 +54,7 @@ function setupTestEnvironment() {
 }
 
 function buildDockerImages() {
-  export CONJUR_APPLIANCE_IMAGE="registry.tld/conjur-appliance:5.0-stable"
+  export CONJUR_APPLIANCE_IMAGE="registry.tld/conjur-appliance:${CONJUR_APPLIANCE_IMAGE_TAG:-5.0-stable}"
 
   docker pull $CONJUR_APPLIANCE_IMAGE
 


### PR DESCRIPTION
Make CONJUR_APPLIANCE_IMAGE tag configurable

Allow users of this repo to use a different tag than `5.0-stable`.
This can be done by setting CONJUR_APPLIANCE_IMAGE_TAG in the env
running the `start` script