### PR TITLE
Add dhparams to master clusters

### DIFF
--- a/6_configure_master.sh
+++ b/6_configure_master.sh
@@ -30,6 +30,10 @@ configure_master_pod() {
     MASTER_ALTNAMES="$MASTER_ALTNAMES,$master_route"
   fi
 
+  echo "Copying $DHPARAMS to /etc/ssl/dhparam.pem in pod ${master_pod_name}..."
+
+  copy_file_to_container "$DHPARAMS" "/etc/ssl/dhparam.pem" "$master_pod_name"
+
   # Configure Conjur master server using evoke.
   $cli exec $master_pod_name -- evoke configure master \
      --accept-eula \

--- a/secrets.yml
+++ b/secrets.yml
@@ -29,6 +29,14 @@ openshift311:
   OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
   OPENSHIFT_REGISTRY_URL: !var ci/openshift/3.11/registry-url
 
+openshift311dev:
+  K8S_VERSION: '1.11'
+  OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+  OPENSHIFT_URL: openshift-311.itd.conjur.net:8443
+  OPENSHIFT_USERNAME: !var dev/openshift/3.11/username
+  OPENSHIFT_PASSWORD: !var dev/openshift/3.11/password
+  OPENSHIFT_REGISTRY_URL: !var dev/openshift/3.11/registry-url
+
 openshift43:
   K8S_VERSION: '1.16'
   OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.3/openshift-client-linux.tar.gz
@@ -44,3 +52,6 @@ openshift43-fips:
   OPENSHIFT_USERNAME: !var ci/openshift/4.3-fips/username
   OPENSHIFT_PASSWORD: !var ci/openshift/4.3-fips/password
   OPENSHIFT_REGISTRY_URL: !var ci/openshift/4.3-fips/registry-url
+
+common:
+  DHPARAMS: !var:file dhparams/4096

--- a/test.sh
+++ b/test.sh
@@ -87,6 +87,8 @@ function test_gke() {
     -e LOCAL_CONJUR_IMAGE \
     -e DOCKER_EMAIL \
     -e FOLLOWER_SEED="" \
+    -v "${DHPARAMS}:/tmp/dhparam.pem" \
+    -e DHPARAMS=/tmp/dhparam.pem \
     -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "$PWD":/src \
@@ -114,6 +116,8 @@ function test_openshift() {
     -e LOCAL_CONJUR_IMAGE \
     -e DOCKER_EMAIL \
     -e FOLLOWER_SEED="" \
+    -v "${DHPARAMS}:/tmp/dhparam.pem" \
+    -e DHPARAMS=/tmp/dhparam.pem \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "$PWD":/src \
     $K8S_CONJUR_DEPLOY_TESTER_IMAGE bash -c "./test_oc_entrypoint.sh"


### PR DESCRIPTION
### What does this PR do?
- A set of pre-generated dhparams are pulled from Conjur and copied into the master appliance image so we don't waste time/compute generating a new set. This should address stability issues in clusters running on OCP/k8s using this repo.

**NOTE:** This was completed to the best of my knowledge but this is a beast of a repo. Someone with broad knowledge of it should conduct the review to evaluate any usage paths this may disrupt.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation