### PR TITLE
Add openshift 3.11 dev environment

### DIFF
--- a/secrets.yml
+++ b/secrets.yml
@@ -29,6 +29,14 @@ openshift311:
   OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
   OPENSHIFT_REGISTRY_URL: !var ci/openshift/3.11/registry-url
 
+openshift311dev:
+  K8S_VERSION: '1.11'
+  OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+  OPENSHIFT_URL: openshift-311.itd.conjur.net:8443
+  OPENSHIFT_USERNAME: !var ci/openshift/3.11/username
+  OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
+  OPENSHIFT_REGISTRY_URL: docker-registry-default.openshift-311.itd.conjur.net
+
 openshift43:
   K8S_VERSION: '1.16'
   OPENSHIFT_CLI_URL: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.3/openshift-client-linux.tar.gz


### PR DESCRIPTION
### What does this PR do?
Adds summon environment for the openshift 3.11 cluster in AWS DEV
This allows developers to use k-c-d with the dev cluster without modifying secrets.yml.
This is important as developers no longer have acecss to the ci clusters.

### What ticket does this PR close?
Related: conjurinc/ops#692

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation