### PR TITLE
Adds RBAC permission for OpenShift DeploymentConfigs

### DIFF
--- a/openshift/conjur-authenticator-role.yaml
+++ b/openshift/conjur-authenticator-role.yaml
@@ -13,6 +13,9 @@ rules:
 - apiGroups: ["apps"]  # needed on OpenShift 3.7+
   resources: [ "deployments", "statefulsets", "replicasets"]
   verbs: ["get", "list"]
+- apiGroups: ["apps.openshift.io"]
+  resources: [ "deploymentconfigs"]
+  verbs: ["get", "list"]
 - apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["create", "get"]


### PR DESCRIPTION
This change adds permissions to get and list `DeploymentConfigs`
resources on OpenShift. This will allow the authn-k8s authenticator
to authenticate based on a client's DeploymentConfig on an
OpenShift platform.

### What does this PR do?
This change adds permissions to get and list `DeploymentConfigs`
resources on OpenShift. This will allow the authn-k8s authenticator
to authenticate based on a client's DeploymentConfig on an
OpenShift platform.

### What ticket does this PR close?
Resolves #157

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation