### PR TITLE
Use ClusterRoleBinding for the authenticator role-binding

### DIFF
--- a/openshift/conjur-authenticator-role-binding.yaml
+++ b/openshift/conjur-authenticator-role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}


### PR DESCRIPTION
Required so that the authenticator can authenticate apps in other
namespaces.

### What does this PR do?
Changes `conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}`  from RoleBinding to ClusterRoleBinding so that the authenticator can authenticate apps in other
namespaces.

### What ticket does this PR close?
Related: conjurinc/ops#692

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation