### PR TITLE
Create dockerpull secret using oc create secret

### DIFF
--- a/2_prepare_docker_images.sh
+++ b/2_prepare_docker_images.sh
@@ -7,7 +7,9 @@ set -euo pipefail
 
 main() {
   if [[ "${PLATFORM}" = "openshift" ]]; then
+    set +x
     docker login -u _ -p $(oc whoami -t) $DOCKER_REGISTRY_PATH
+    set -x
   fi
 
   if [[ $CONJUR_DEPLOYMENT == oss ]]; then

--- a/3_deploy_conjur_master_cluster.sh
+++ b/3_deploy_conjur_master_cluster.sh
@@ -26,23 +26,23 @@ docker_login() {
       $cli delete --ignore-not-found secret dockerpullsecret
 
       $cli create secret docker-registry dockerpullsecret \
-           --docker-server=$DOCKER_REGISTRY_URL \
-           --docker-username=$DOCKER_USERNAME \
-           --docker-password=$DOCKER_PASSWORD \
-           --docker-email=$DOCKER_EMAIL
+         --docker-server=$DOCKER_REGISTRY_URL \
+         --docker-username=$DOCKER_USERNAME \
+         --docker-password=$DOCKER_PASSWORD \
+         --docker-email=$DOCKER_EMAIL
     fi
   elif [[ $PLATFORM = 'openshift' ]] && ([ -z ${OPENSHIFT_VERSION+x} ] || (! [ -z ${OPENSHIFT_VERSION+x} ] && ! [[ $OPENSHIFT_VERSION =~ ^4 ]])); then
     announce "Creating image pull secret."
 
     $cli delete --ignore-not-found secrets dockerpullsecret
 
-    $cli secrets new-dockercfg dockerpullsecret \
-         --docker-server=${DOCKER_REGISTRY_PATH} \
-         --docker-username=_ \
-         --docker-password=$($cli whoami -t) \
-         --docker-email=_
+    $cli create secret docker-registry dockerpullsecret \
+      --docker-server=${DOCKER_REGISTRY_PATH} \
+      --docker-username=_ \
+      --docker-password=$($cli whoami -t) \
+      --docker-email=_
 
-    $cli secrets add serviceaccount/conjur-cluster secrets/dockerpullsecret --for=pull
+    $cli secrets link serviceaccount/conjur-cluster dockerpullsecret --for=pull
   fi
 }
 

--- a/test_gke_entrypoint.sh
+++ b/test_gke_entrypoint.sh
@@ -50,7 +50,9 @@ function main() {
 function initialize() {
   gcloud auth activate-service-account --key-file $GCLOUD_SERVICE_KEY
   gcloud container clusters get-credentials $GCLOUD_CLUSTER_NAME --zone $GCLOUD_ZONE --project $GCLOUD_PROJECT_NAME
+  set +x
   docker login $DOCKER_REGISTRY_URL -u oauth2accesstoken -p $(gcloud auth print-access-token)
+  set -x
 }
 
 function runScripts() {

--- a/test_oc_entrypoint.sh
+++ b/test_oc_entrypoint.sh
@@ -45,8 +45,17 @@ function main() {
 }
 
 function initialize() {
-  oc login $OPENSHIFT_URL --username=$OPENSHIFT_USERNAME --password=$OPENSHIFT_PASSWORD --insecure-skip-tls-verify=true
-  docker login -u _ -p $(oc whoami -t) $OPENSHIFT_REGISTRY_URL
+  set +x
+  oc login "$OPENSHIFT_URL" \
+    --username="$OPENSHIFT_USERNAME" \
+    --password="$OPENSHIFT_PASSWORD" \
+    --insecure-skip-tls-verify=true
+
+  docker login \
+    -u _ \
+    -p $(oc whoami -t) \
+    "$OPENSHIFT_REGISTRY_URL"
+  set -x
 }
 
 function runScripts() {

--- a/utils.sh
+++ b/utils.sh
@@ -181,9 +181,11 @@ set_conjur_pod_log_level() {
 
 oc_login() {
   echo "Logging in as cluster admin..."
+  set +x
   if [ -z ${OPENSHIFT_PASSWORD+x} ]; then
     oc login -u $OPENSHIFT_USERNAME
   else
     oc login -u $OPENSHIFT_USERNAME -p $OPENSHIFT_PASSWORD
   fi
+  set -x
 }


### PR DESCRIPTION
The command "new-dockercfg" is deprecated, and it is best
to use `oc create secret` instead.

This [`kubernetes-conjur-demo` build](https://jenkins.conjur.net/blue/organizations/jenkins/conjurdemos--kubernetes-conjur-demo/detail/use-create-secret/3/pipeline/) verifies this change.
