### PR TITLE
Remove explicit tests for OCP 4.3 FIPS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,11 +30,6 @@ pipeline {
             sh 'summon --environment openshift43 ./test.sh openshift43 5'
           }
         }
-        stage('Test on OpenShift 4.3-fips in AWS') {
-         steps {
-           sh 'summon --environment openshift43-fips ./test.sh openshift43-fips 5'
-         }
-        }
         stage('Test on current OpenShift in AWS') {
           steps {
             sh 'summon --environment openshift_current ./test.sh openshift_current 5'

--- a/secrets.yml
+++ b/secrets.yml
@@ -23,10 +23,10 @@ openshift311dev:
 
 openshift43:
   OPENSHIFT_VERSION: '4.3'
-  OPENSHIFT_URL: !var ci/openshift/4.3/api-url
-  OPENSHIFT_USERNAME: !var ci/openshift/4.3/username
-  OPENSHIFT_PASSWORD: !var ci/openshift/4.3/password
-  OPENSHIFT_REGISTRY_URL: !var ci/openshift/4.3/registry-url
+  OPENSHIFT_URL: !var ci/openshift/oldest/api-url
+  OPENSHIFT_USERNAME: !var ci/openshift/oldest/username
+  OPENSHIFT_PASSWORD: !var ci/openshift/oldest/password
+  OPENSHIFT_REGISTRY_URL: !var ci/openshift/oldest/registry-url
 
 openshift_current:
   OPENSHIFT_VERSION: !var ci/openshift/current/version

--- a/secrets.yml
+++ b/secrets.yml
@@ -28,13 +28,6 @@ openshift43:
   OPENSHIFT_PASSWORD: !var ci/openshift/4.3/password
   OPENSHIFT_REGISTRY_URL: !var ci/openshift/4.3/registry-url
 
-openshift43-fips:
-  OPENSHIFT_VERSION: '4.3'
-  OPENSHIFT_URL: !var ci/openshift/4.3-fips/api-url
-  OPENSHIFT_USERNAME: !var ci/openshift/4.3-fips/username
-  OPENSHIFT_PASSWORD: !var ci/openshift/4.3-fips/password
-  OPENSHIFT_REGISTRY_URL: !var ci/openshift/4.3-fips/registry-url
-
 openshift_current:
   OPENSHIFT_VERSION: !var ci/openshift/current/version
   OPENSHIFT_URL: !var ci/openshift/current/api-url


### PR DESCRIPTION
### What does this PR do?
Our new OCP 4.3 cluster is FIPS-compliant so we don't need to run the tests
explicitly on another OCP 4.3 FIPS-compliant cluster

### Checklists

#### Change log
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation