### PR TITLE
Eliminates hanging when deleting namespace for OpenShift 4.3

### DIFF
--- a/stop
+++ b/stop
@@ -11,6 +11,17 @@ fi
 set_namespace default
 
 if has_namespace $CONJUR_NAMESPACE_NAME; then
+  if [[ "$PLATFORM" == "openshift" && "$OPENSHIFT_VERSION" == "4.3" ]]; then
+    # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282
+    for svc in `$cli get svc -n "$CONJUR_NAMESPACE_NAME" -o name`; do
+      echo "Deleting finalizers from Kubernetes service $svc"
+      "$cli" patch "$svc" \
+          --namespace "$CONJUR_NAMESPACE_NAME" \
+          --type=json \
+          --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
+    done
+  fi
+
   $cli delete namespace $CONJUR_NAMESPACE_NAME
 
   printf "Waiting for $CONJUR_NAMESPACE_NAME namespace deletion to complete"


### PR DESCRIPTION
### What does this PR do?
This change adds a workaround for this OpenShift 4.3 bug:
     
     https://bugzilla.redhat.com/show_bug.cgi?id=1798282

Without this fix, deleting a namespace on OpenShift 4.3 could result
in indefinite hanging due to finalizers that are not being
deleted from services in the namespace.

NOTE: Jenkins tests are currently failing for Current OpenShift on AWS.
These failures are apparently unrelated to the fix proposed here since
they are also occuring on the master branch.

### What ticket does this PR close?
Resolves #167 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation