### PR TITLE
Protect 43 teardown

### DIFF
--- a/6_configure_master.sh
+++ b/6_configure_master.sh
@@ -21,15 +21,6 @@ configure_master_pod() {
 
   MASTER_ALTNAMES="localhost,conjur-master"
 
-  if [ $PLATFORM = 'openshift' ]; then
-    $cli create route passthrough --service=conjur-master-ext
-    echo "Created passthrough route for conjur-master-ext service."
-
-    # Add OpenShift route name to Master altnames to prevent cert errors
-    master_route=$(oc get routes | grep conjur-master-ext | awk '{print $2}')
-    MASTER_ALTNAMES="$MASTER_ALTNAMES,$master_route"
-  fi
-
   # Configure Conjur master server using evoke.
   $cli exec $master_pod_name -- evoke configure master \
      --accept-eula \

--- a/9_print_cluster_info.sh
+++ b/9_print_cluster_info.sh
@@ -4,22 +4,17 @@ set -euo pipefail
 . utils.sh
 
 main() {
-  set_namespace $CONJUR_NAMESPACE_NAME
+  set_namespace "$CONJUR_NAMESPACE_NAME"
 
   print_cluster_info
 }
 
 print_cluster_info() {
-  if [ $PLATFORM = 'kubernetes' ]; then
-    if is_minienv; then
-      master_nodeport=$(kubectl describe service conjur-master | grep NodePort: | grep https | awk '{print $3}' | cut -d'/' -f 1)
-      ui_url="https://$(minikube ip):$master_nodeport"
-    else
-      ui_url="https://$(get_master_service_ip)"
-    fi
-  elif [ $PLATFORM = 'openshift' ]; then
-    conjur_master_route=$($cli get routes | grep conjur-master | awk '{ print $2 }')
-    ui_url="https://$conjur_master_route"
+  if [ "$PLATFORM" = 'kubernetes' ] && is_minienv; then
+    master_nodeport=$(kubectl describe service conjur-master | grep NodePort: | grep https | awk '{print $3}' | cut -d'/' -f 1)
+    ui_url="https://$(minikube ip):$master_nodeport"
+  else
+    ui_url="No external access for Conjur cluster created"
   fi
 
   password=$CONJUR_ADMIN_PASSWORD
@@ -35,4 +30,4 @@ print_cluster_info() {
   "
 }
 
-main $@
+main "$@"

--- a/README.md
+++ b/README.md
@@ -232,6 +232,14 @@ The [kubernetes-conjur-demo repo](https://github.com/conjurdemos/kubernetes-conj
 deploys test applications that retrieve secrets from Conjur and serves as a
 useful reference when setting up your own applications to integrate with Conjur.
 
+# Conjur cluster load balancer
+If a Conjur cluster is deployed within the kubernetes/openshift cluster, by default an external facing load balancer will
+not be deployed with it.  For convenience, `(kubernetes|openshift)/conjur-cluster-ext-service.yaml` are provided for 
+creating and mapping the load balancer.  It can be applied with:
+
+```
+kubectl create -f "./$PLATFORM/conjur-cluster-ext-service.yaml"
+```
 
 # Contributing
 

--- a/kubernetes/conjur-cluster-ext-service.yaml
+++ b/kubernetes/conjur-cluster-ext-service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: conjur-master
+  name: conjur-master-ext
   labels:
-    app: conjur-cluster-svc
+    app: conjur-cluster-svc-ext
 spec:
-  # This service allows other in-cluster services to reach the master since
-  # LoadBalancer doesn't expose internal routing.
-  type: ClusterIP
+  # LoadBalancer is enabling our external-to-cluster ingress into
+  # the master. This allows it to be usable from the outside of K8s.
+  type: LoadBalancer
   selector:
     app: conjur-node
   ports:

--- a/openshift/conjur-cluster-ext-service.yaml
+++ b/openshift/conjur-cluster-ext-service.yaml
@@ -1,14 +1,14 @@
----
+----
 apiVersion: v1
 kind: Service
 metadata:
-  name: conjur-master
+  name: conjur-master-ext
   labels:
-    app: conjur-cluster-svc
+    app: conjur-cluster-svc-ext
 spec:
-  # This service allows other in-cluster services to reach the master since
-  # LoadBalancer doesn't expose internal routing.
-  type: ClusterIP
+  # LoadBalancer is enabling our external-to-cluster ingress into
+  # the master. This allows it to be usable from the outside of K8s.
+  type: LoadBalancer
   selector:
     app: conjur-node
   ports:

--- a/openshift/conjur-cluster-service.yaml
+++ b/openshift/conjur-cluster-service.yaml
@@ -2,33 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: conjur-master-ext
-  labels:
-    app: conjur-cluster-svc-ext
-spec:
-  # LoadBalancer is enabling our external-to-cluster ingress into
-  # the master. This allows it to be usable from the outside of K8s.
-  type: LoadBalancer
-  selector:
-    app: conjur-node
-  ports:
-  - name: https
-    protocol: TCP
-    port: 443
-  - name: ldaps
-    protocol: TCP
-    port: 663
-  - name: pg-main
-    protocol: TCP
-    port: 5432
-  - name: syslog-audit
-    protocol: TCP
-    port: 1999
-
----
-apiVersion: v1
-kind: Service
-metadata:
   name: conjur-master
   labels:
     app: conjur-cluster-svc

--- a/stop
+++ b/stop
@@ -10,24 +10,24 @@ fi
 
 set_namespace default
 
-if has_namespace $CONJUR_NAMESPACE_NAME; then
-  if [[ "$PLATFORM" == "openshift" && "$OPENSHIFT_VERSION" == "4.3" ]]; then
-    # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1798282
-    for svc in `$cli get svc -n "$CONJUR_NAMESPACE_NAME" -o name`; do
-      echo "Deleting finalizers from Kubernetes service $svc"
-      "$cli" patch "$svc" \
-          --namespace "$CONJUR_NAMESPACE_NAME" \
-          --type=json \
-          --patch='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
-    done
-  fi
+result=0
 
-  $cli delete namespace $CONJUR_NAMESPACE_NAME
+if has_namespace $CONJUR_NAMESPACE_NAME; then
+  $cli --request-timeout=5m delete namespace $CONJUR_NAMESPACE_NAME
 
   printf "Waiting for $CONJUR_NAMESPACE_NAME namespace deletion to complete"
 
+  # Wait up to 10 minutes for namespace deletion to complete
+  wait_time=600
   while has_namespace "$CONJUR_NAMESPACE_NAME"; do
     printf "."
+    wait_time=$(( wait_time - 5 ))
+    if [ "$wait_time" -lt 0 ]; then
+      echo ""
+      echo "Timeout deleting namespace ${CONJUR_NAMESPACE_NAME}"
+      result=1
+      break
+    fi
     sleep 5
   done
 
@@ -37,4 +37,10 @@ fi
 echo "Deleting cluster role"
 $cli delete --ignore-not-found clusterrole conjur-authenticator-$CONJUR_NAMESPACE_NAME
 
-echo "Conjur environment purged."
+if [ "$result" -ne 0 ]; then
+  echo "Failed to purge conjur environment"
+else
+  echo "Conjur environment purged."
+fi
+
+exit $result


### PR DESCRIPTION
### What does this PR do?
There is a bug in OpenShift 4.3 that results in it being unable to tear down ELBs that were created from a service defined as `type: LoadBalancer`.  The current `stop` script bypasses the issue by removing finalizers, but that results in ELBs persisting after the run.  To fix this, the external load balancers need to not be created for 4.3 clusters.  To handle this, `kubernetes-conjur-deploy` will no longer deploy external facing load balancers.  The yaml config for kubernetes and openshift is included should someone want to deploy it manually.

-  This no longer deploys external facing load balancers
-  This removes special casing for OC 4.3 and enforces a timeout
    on deleting the namespace. If a namespace fails to be deleted within
    5 minutes it will result in the script exiting with an error.  The
    previous special casing behavior for OC 4.3 would leave ELBs and
    not properly clean up resources.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation