### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ Docker Desktop provides a convenient way to deploy and develop from your machine
 
 1. By default, 2.0 Gib of memory is allocated to Docker on your computer. 
 
-   To successfully deploy a DAP cluster (Master + Followers + Standbys), you will need to increase the memory limit to 6 Gib. To do so, perform the following:
+   To successfully deploy a Conjur Enterprise cluster (Master + Followers + Standbys), you will need to increase the memory limit to 6 Gib. To do so, perform the following:
    
    1. Navigate to Docker preferences
    

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ followers to a Kubernetes or OpenShift environment. These scripts can also be
 used to deploy a full cluster with Master and Standbys for testing and demo
 purposes but this is not recommended for a production deployment of Conjur.
 
-**This repo supports CyberArk DAP v10+**. To deploy Conjur OSS, please use
-the [Conjur OSS helm chart](https://github.com/cyberark/conjur-oss-helm-chart).
+**This repo supports CyberArk Conjur Enterprise (formerly DAP) v10+**. To deploy Conjur Open Source, please use
+the [Conjur Open Source helm chart](https://github.com/cyberark/conjur-oss-helm-chart).
 
 ---
 


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
