### PR TITLE
Eliminate 500 internal server errors when configuring CLI Pod

### DIFF
--- a/6.5_configure_cli_pod.sh
+++ b/6.5_configure_cli_pod.sh
@@ -13,19 +13,19 @@ configure_cli_pod() {
 
   conjur_url="https://$CONJUR_NODE_NAME.$CONJUR_NAMESPACE_NAME.svc.cluster.local"
 
-  conjur_cli_pod=$(get_conjur_cli_pod_name)
+  conjur_cli_pod="$(get_conjur_cli_pod_name)"
   # We saw gke env take time to up.
   wait_for_it 300 "$cli exec $conjur_cli_pod -- bash -c \"yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url\""
 
   if [[ $CONJUR_DEPLOYMENT == oss ]]; then
     # Set admin password. In DAP this happens in `evoke configure master`
-    conjur_pod=$($cli get pods | grep conjur-oss | cut -f 1 -d ' ')
-    $cli exec $conjur_pod -c conjur conjurctl account create $CONJUR_ACCOUNT > /dev/null
-    conjur_admin_api_key=$($cli exec $conjur_pod -c conjur conjurctl role retrieve-key $CONJUR_ACCOUNT:user:admin | cut -f 5 -d ' ')
-    $cli exec $conjur_cli_pod -- conjur authn login -u admin -p $conjur_admin_api_key
-    $cli exec $conjur_cli_pod -- conjur user update_password -p $CONJUR_ADMIN_PASSWORD
+    conjur_pod="$($cli get pods | grep conjur-oss | cut -f 1 -d ' ')"
+    "$cli" exec "$conjur_pod" -c conjur -- conjurctl account create "$CONJUR_ACCOUNT" > /dev/null
+    conjur_admin_api_key="$($cli exec $conjur_pod -c conjur -- conjurctl role retrieve-key $CONJUR_ACCOUNT:user:admin | cut -f 5 -d ' ')"
+    wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur authn login -u admin -p $conjur_admin_api_key"
+    wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur user update_password -p $CONJUR_ADMIN_PASSWORD"
   fi
-  $cli exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
+  wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD"
 }
 
 main $@


### PR DESCRIPTION


This is an intermittent error that occurs when we're trying to log into
Conjur. I don't know the root cause, but executing Conjur CLI commands
inside a retry loop will fix the issue.

### Desired Outcome

Running the deploy scripts for Conjur OSS does not result in `500 Internal Server Error` errors.

Currently, when the deploy scripts are run for Conjur OSS, when we get to the point where the Conjur CLI Pod is being configured (in the `6.5_configure_cli_pod.sh` script), we see the following error:

```
[2021-12-16T17:02:27.708Z] ++++++++++++++++++++++++++++++++++++++
[2021-12-16T17:02:27.708Z]
[2021-12-16T17:02:27.708Z] Configuring Conjur CLI.
[2021-12-16T17:02:27.708Z]
[2021-12-16T17:02:27.708Z] ++++++++++++++++++++++++++++++++++++++
     . . .
[2021-12-16T17:02:44.490Z] Logged in
     . . .
[2021-12-16T17:02:47.260Z] error: 500 Internal Server Error
     . . .
[2021-12-16T17:02:47.260Z] command terminated with exit code 1
```

This is an intermittent error that occurs when we're trying to log into Conjur. I don't know the root cause, but executing Conjur CLI commands inside a retry loop will fix the issue.

### Implemented Changes

- Commands that are executed in the Conjur CLI Pod are now run within a retry loop.
- Added quotes around Bash variable references, as required by our Bash style guides.
- For commands executed inside the Conjur CLI Pod, added `--` between instances of `$cli exec <conjur-cli-pod-name> -c <container>` and the command to be executed inside the Conjur CLI pod. Not using the `--` is deprecated syntax.

### Connected Issue/Story

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
