### PR TITLE
Fix for running with local environment

### DIFF
--- a/2_prepare_docker_images.sh
+++ b/2_prepare_docker_images.sh
@@ -88,6 +88,16 @@ prepare_conjur_oss_cluster() {
     docker push "$conjur_oss_dest_image"
   fi
 
+  announce "Pulling and pushing postgres image"
+  
+  postgres_src_image="postgres:10"
+  docker pull "$postgres_src_image"
+  if [ "${DEV}" = "false" ]; then
+    postgres_dest_image=$(platform_image "postgres")
+    docker tag "$postgres_src_image" "$postgres_dest_image"
+    docker push "$postgres_dest_image"
+  fi
+
   announce "Pulling and pushing Nginx image."
 
   nginx_image=$(platform_image "nginx")


### PR DESCRIPTION
### Desired Outcome

Developers should be able to spin up a dev environment on their local machines. Currently this doesn't work because the ImagePullPolicy is set to 'Never' in dev mode, which will cause the script to fail when trying to create a postgres instance because the script doesn't pull the postgres image beforehand.

To reproduce issue:
Clone the secrets-provider-for-k8s repo and run `./bin/start --dev --oss`. The script will clone the kubernetes-conjur-deploy repository and attempt to deploy a local cluster, but will timeout when it tries to deploy conjur-postgres. Checking the kubernetes logs, you'll see "Container image "postgres:10" is not present with pull policy of Never".
You can confirm the fix by editing the `git clone git@github.com:cyberark/kubernetes-conjur-deploy` line to add `-b localbuild` which will use this branch instead of master.

### Implemented Changes

- In dev mode, pull the postgres image manually

### Connected Issue/Story

N/A

### Definition of Done
- [x] Script runs successfully with DEV=true

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
