### PR TITLE
Remove OpenShift v3.11 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,12 +28,6 @@ pipeline {
           }
         }
 
-        stage('Test on OpenShift 3.11 in AWS') {
-          steps {
-            sh 'summon --environment openshift311 ./test.sh openshift311 5'
-          }
-        }
-
         stage('OpenShift Oldest 4.x') {
           steps {
             sh 'summon --environment openshift_oldest ./test.sh openshift_oldest 5'

--- a/secrets.yml
+++ b/secrets.yml
@@ -5,22 +5,6 @@ kubernetes:
   GCLOUD_SERVICE_KEY: !var:file ci/gke/service-key
   KUBECTL_CLI_URL: https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
 
-openshift311:
-  OPENSHIFT_VERSION: '3.11'
-  OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
-  OPENSHIFT_URL: openshift-311.itci.conjur.net:8443
-  OPENSHIFT_USERNAME: !var ci/openshift/3.11/username
-  OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
-  OPENSHIFT_REGISTRY_URL: !var ci/openshift/3.11/registry-url
-
-openshift311dev:
-  OPENSHIFT_VERSION: '3.11'
-  OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
-  OPENSHIFT_URL: openshift-311.itd.conjur.net:8443
-  OPENSHIFT_USERNAME: !var ci/openshift/3.11/username
-  OPENSHIFT_PASSWORD: !var ci/openshift/3.11/password
-  OPENSHIFT_REGISTRY_URL: docker-registry-default.openshift-311.itd.conjur.net
-
 openshift_oldest:
   OPENSHIFT_VERSION: !var ci/openshift/oldest/version
   OPENSHIFT_URL: !var ci/openshift/oldest/api-url


### PR DESCRIPTION
### Desired Outcome

Remove support for testing against OCP v3.11 as it is now EoL and we are discontinuing support.

### Implemented Changes

All references to v3.11 are removed including documentation and test tooling.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: ONYX-22651
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
