### PR TITLE
Update ClusterRole apiVersion

### DIFF
--- a/openshift/conjur-authenticator-role.yaml
+++ b/openshift/conjur-authenticator-role.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: conjur-authenticator-{{ CONJUR_NAMESPACE_NAME }}


### PR DESCRIPTION
### Desired Outcome

```
Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "authorization.openshift.io/v1" for your resource
```

This deprecation has started causing failures in CI for cyberark/secrets-provider-for-k8s:

```
error: resource mapping not found for name: "conjur-authenticator-conjur-572ae17d-d" namespace: "" from "STDIN": no matches for kind "ClusterRole" in version "v1"
```

### Implemented Changes

Updates ClusterRole apiVersion from ungrouped `v1` to grouped `rbac.authorization.k8s.io/v1`

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
