### PR TITLE
Update kubectl exec syntax

### DIFF
--- a/7_configure_standbys.sh
+++ b/7_configure_standbys.sh
@@ -27,7 +27,7 @@ prepare_standby_seed() {
   seed_dir="tmp-$CONJUR_NAMESPACE_NAME"
   mkdir -p $seed_dir
 
-  $cli exec $master_pod_name evoke seed standby conjur-standby > "./$seed_dir/standby-seed.tar"
+  $cli exec $master_pod_name -- evoke seed standby conjur-standby > "./$seed_dir/standby-seed.tar"
 }
 
 configure_standbys() {

--- a/8_configure_followers.sh
+++ b/8_configure_followers.sh
@@ -32,7 +32,7 @@ prepare_follower_seed() {
 
   FOLLOWER_SEED="./$seed_dir/follower-seed.tar"
 
-  $cli exec $master_pod_name evoke seed follower conjur-follower > $FOLLOWER_SEED
+  $cli exec $master_pod_name -- evoke seed follower conjur-follower > $FOLLOWER_SEED
 }
 
 configure_followers() {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,11 +108,11 @@ the CLI pod and SSH into it:
 ```
 # Kubernetes
 kubectl create -f ./kubernetes/conjur-cli.yaml
-kubectl exec -it [cli-pod-name] bash
+kubectl exec -it [cli-pod-name] -- bash
 
 # OpenShift
 oc create -f ./openshift/conjur-cli.yaml
-oc exec -it <cli-pod-name> bash
+oc exec -it <cli-pod-name> -- bash
 ```
 
 Once inside the CLI container, use the admin credentials to connect to Conjur:


### PR DESCRIPTION
### Desired Outcome

Remove warning:

> kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.

### Implemented Changes

Update `kubectl exec` command syntax to put a `--` before the command.

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
