### PR TITLE
Use Conjur CLI v8.0

### DIFF
--- a/0_check_dependencies.sh
+++ b/0_check_dependencies.sh
@@ -22,7 +22,6 @@ if [ "${PLATFORM}" = "openshift" ]; then
 fi
 
 if [[ "${DEPLOY_MASTER_CLUSTER}" = "true" ]]; then
-  check_env_var "CONJUR_VERSION"
   check_env_var "CONJUR_ACCOUNT"
   check_env_var "CONJUR_ADMIN_PASSWORD"
 fi

--- a/2_prepare_docker_images.sh
+++ b/2_prepare_docker_images.sh
@@ -45,14 +45,21 @@ prepare_conjur_appliance_image() {
 prepare_conjur_cli_image() {
   announce "Pulling and pushing Conjur CLI image."
 
-  docker pull cyberark/conjur-cli:$CONJUR_VERSION-latest
-  docker tag cyberark/conjur-cli:$CONJUR_VERSION-latest conjur-cli:$CONJUR_NAMESPACE_NAME
+  docker pull cyberark/conjur-cli:8
+  docker tag cyberark/conjur-cli:8 conjur-cli:$CONJUR_NAMESPACE_NAME
+
+  docker pull alpine:latest
+  docker tag alpine:latest alpine:$CONJUR_NAMESPACE_NAME
 
   cli_app_image=$(platform_image conjur-cli)
   docker tag conjur-cli:$CONJUR_NAMESPACE_NAME $cli_app_image
 
+  alpine_image=$(platform_image alpine)
+  docker tag alpine:$CONJUR_NAMESPACE_NAME $alpine_image
+
   if [ ! is_minienv ] || [ "${DEV}" = "false" ]; then
     docker push $cli_app_image
+    docker push $alpine_image
   fi
 }
 

--- a/3_deploy_conjur_master_cluster.sh
+++ b/3_deploy_conjur_master_cluster.sh
@@ -10,6 +10,7 @@ main() {
 
   deploy_conjur_master_cluster
   deploy_conjur_cli
+  deploy_test_curl
 
   sleep 10
 
@@ -89,6 +90,15 @@ deploy_conjur_cli() {
 
   cli_app_image=$(platform_image conjur-cli true)
   sed -e "s#{{ DOCKER_IMAGE }}#$cli_app_image#g" ./$PLATFORM/conjur-cli.yml |
+    sed -e "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
+    $cli create -f -
+}
+
+deploy_test_curl() {
+  announce "Deploying Test curl pod."
+
+  alpine_image=$(platform_image alpine true)
+  sed -e "s#{{ DOCKER_IMAGE }}#$alpine_image#g" ./$PLATFORM/test-curl.yml |
     sed -e "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
     $cli create -f -
 }

--- a/6.5_configure_cli_pod.sh
+++ b/6.5_configure_cli_pod.sh
@@ -15,17 +15,17 @@ configure_cli_pod() {
 
   conjur_cli_pod="$(get_conjur_cli_pod_name)"
   # We saw gke env take time to up.
-  wait_for_it 300 "$cli exec $conjur_cli_pod -- bash -c \"yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url\""
+  wait_for_it 300 "$cli exec $conjur_cli_pod -- sh -c \"echo y | conjur init --self-signed --force -a $CONJUR_ACCOUNT -u $conjur_url\""
 
   if [[ $CONJUR_DEPLOYMENT == oss ]]; then
     # Set admin password. In DAP this happens in `evoke configure master`
     conjur_pod="$($cli get pods | grep conjur-oss | cut -f 1 -d ' ')"
     "$cli" exec "$conjur_pod" -c conjur -- conjurctl account create "$CONJUR_ACCOUNT" > /dev/null
     conjur_admin_api_key="$($cli exec $conjur_pod -c conjur -- conjurctl role retrieve-key $CONJUR_ACCOUNT:user:admin | cut -f 5 -d ' ')"
-    wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur authn login -u admin -p $conjur_admin_api_key"
-    wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur user update_password -p $CONJUR_ADMIN_PASSWORD"
+    wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur login -i admin -p $conjur_admin_api_key"
+    wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur user change-password -p $CONJUR_ADMIN_PASSWORD"
   fi
-  wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD"
+  wait_for_it 300 "$cli exec $conjur_cli_pod -- conjur login -i admin -p $CONJUR_ADMIN_PASSWORD"
 }
 
 main $@

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,18 +31,8 @@ export DEPLOY_MASTER_CLUSTER=true
 ```
 
 You will also need to set a few environment variable that are only used when
-configuring the Conjur master. If you are working with Conjur that is not v5,
-```
-export CONJUR_VERSION=<conjur_version>
-```
-along with any other changes you might want.
-
-Otherwise, this variable will default to `5`.
-
-_Note: If you are using Conjur v4, please use [v4_support](https://github.com/cyberark/kubernetes-conjur-deploy/tree/v4_support)
-branch of this repo!_
-
-You must also provide an account name and password for the Conjur admin account:
+configuring the Conjur master. You must provide an account name and password
+for the Conjur admin account:
 
 ```
 export CONJUR_ACCOUNT=<my_account_name>
@@ -108,11 +98,11 @@ the CLI pod and SSH into it:
 ```
 # Kubernetes
 kubectl create -f ./kubernetes/conjur-cli.yaml
-kubectl exec -it [cli-pod-name] -- bash
+kubectl exec -it [cli-pod-name] -- sh
 
 # OpenShift
 oc create -f ./openshift/conjur-cli.yaml
-oc exec -it <cli-pod-name> -- bash
+oc exec -it <cli-pod-name> -- sh
 ```
 
 Once inside the CLI container, use the admin credentials to connect to Conjur:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,28 +22,28 @@ pipeline {
   stages {
     stage('Run Scripts') {
       parallel {
-        stage('Test v5 on GKE') {
+        stage('Test on GKE') {
           steps {
-            sh 'summon --environment kubernetes ./test.sh gke 5'
+            sh 'summon --environment kubernetes ./test.sh gke'
           }
         }
 
         stage('OpenShift Oldest 4.x') {
           steps {
-            sh 'summon --environment openshift_oldest ./test.sh openshift_oldest 5'
+            sh 'summon --environment openshift_oldest ./test.sh openshift_oldest'
           }
         }
 
         stage('OpenShift Current 4.x') {
           steps {
-            sh 'summon --environment openshift_current ./test.sh openshift_current 5'
+            sh 'summon --environment openshift_current ./test.sh openshift_current'
           }
         }
 
         stage('OpenShift Next 4.x') {
           when { expression { return params.TEST_OCP_NEXT } }
           steps {
-            sh 'summon --environment openshift_next ./test.sh openshift_next 5'
+            sh 'summon --environment openshift_next ./test.sh openshift_next'
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ The Conjur appliance image can be loaded with `_load_conjur_tarfile.sh`. The scr
 
 ### Conjur Configuration
 
-_Note: If you are using Conjur v4, please use [v4_support](https://github.com/cyberark/kubernetes-conjur-deploy/tree/v4_support)
-branch of this repo!_
-
 #### Appliance Image
 
 You need to obtain a Docker image of the Conjur appliance and push it to an

--- a/bootstrap.env
+++ b/bootstrap.env
@@ -5,7 +5,6 @@
 # platform you're not using, and fill in the
 # appropriate values for each env var
 
-export CONJUR_VERSION=5
 export CONJUR_APPLIANCE_IMAGE=[local Conjur Docker image - should match master version]
 export CONJUR_ACCOUNT=[name of conjur account with which to authenticate to seed service]
 

--- a/dev-bootstrap.env
+++ b/dev-bootstrap.env
@@ -5,9 +5,7 @@
 # platform you're not using, and fill in the
 # appropriate values for each env var
 
-export CONJUR_VERSION=5
-export CONJUR_MINOR_VERSION=0
-export CONJUR_APPLIANCE_IMAGE="conjur-appliance:$CONJUR_VERSION.$CONJUR_MINOR_VERSION-stable"
+export CONJUR_APPLIANCE_IMAGE="conjur-appliance:5.0-stable"
 
 # We generate a random namespace suffix if you don't provide one
 if [ -z "${CONJUR_NAMESPACE_SUFFIX}" ]; then

--- a/exec-into-cli.sh
+++ b/exec-into-cli.sh
@@ -2,5 +2,5 @@
 . ./utils.sh
 set_namespace $CONJUR_NAMESPACE_NAME
 conjur_cli_pod=$(get_conjur_cli_pod_name)
-$cli exec -it $conjur_cli_pod -- bash
+$cli exec -it $conjur_cli_pod -- sh
 set_namespace $TEST_APP_NAMESPACE_NAME

--- a/kubernetes/test-curl.yml
+++ b/kubernetes/test-curl.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-curl
+  labels:
+    app: test-curl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-curl
+  template:
+    metadata:
+      name: test-curl
+      labels:
+        app: test-curl
+    spec:
+      serviceAccountName: conjur-cluster
+      containers:
+      - name: test-curl
+        image: {{ DOCKER_IMAGE }}
+        imagePullPolicy: {{ IMAGE_PULL_POLICY }}
+        command: ["/bin/sh", "-c", "apk --no-cache add curl; sleep infinity"]
+

--- a/openshift/test-curl.yml
+++ b/openshift/test-curl.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-curl
+  labels:
+    app: test-curl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-curl
+  template:
+    metadata:
+      name: test-curl
+      labels:
+        app: test-curl
+    spec:
+      serviceAccountName: conjur-cluster
+      containers:
+      - name: test-curl
+        image: {{ DOCKER_IMAGE }}
+        imagePullPolicy: {{ IMAGE_PULL_POLICY }}
+        command: ["/bin/sh", "-c", "apk --no-cache add curl; sleep infinity"]
+

--- a/test.sh
+++ b/test.sh
@@ -9,9 +9,6 @@ set -o pipefail
 TEST_PLATFORM="$1"
 export TEST_PLATFORM
 
-CONJUR_VERSION="$2"
-export CONJUR_VERSION
-
 CONJUR_DEPLOYMENT="dap"
 export CONJUR_DEPLOYMENT
 
@@ -90,7 +87,6 @@ function test_gke() {
     -e CONJUR_NAMESPACE_NAME \
     -e DOCKER_REGISTRY_URL \
     -e DOCKER_REGISTRY_PATH \
-    -e CONJUR_VERSION \
     -e CONJUR_DEPLOYMENT \
     -e CONJUR_ACCOUNT \
     -e CONJUR_ADMIN_PASSWORD \
@@ -117,7 +113,6 @@ function test_openshift() {
     -e CONJUR_APPLIANCE_IMAGE \
     -e CONJUR_NAMESPACE_NAME \
     -e DOCKER_REGISTRY_PATH \
-    -e CONJUR_VERSION \
     -e CONJUR_DEPLOYMENT \
     -e CONJUR_ACCOUNT \
     -e CONJUR_ADMIN_PASSWORD \

--- a/test_gke_entrypoint.sh
+++ b/test_gke_entrypoint.sh
@@ -40,11 +40,6 @@ function main() {
   getGKEVersion
   initialize
   runScripts
-
-  # Removed this since our current advice is to run the Conjur 4 master outside cluster. Dustin Collins, 2018.12.12.
-  # if [ $CONJUR_VERSION = '4' ]; then
-  #   relaunchMaster
-  # fi
 }
 
 function initialize() {

--- a/utils.sh
+++ b/utils.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-CONJUR_VERSION=${CONJUR_VERSION:-5} # default to v5 if not set
 PLATFORM="${PLATFORM:-kubernetes}" # default to kubernetes if not set
 DEPLOY_MASTER_CLUSTER="${DEPLOY_MASTER_CLUSTER:-false}"
 FOLLOWER_USE_VOLUMES="${FOLLOWER_USE_VOLUMES:-false}"
@@ -100,6 +99,11 @@ mastercmd() {
 
 get_conjur_cli_pod_name() {
   pod_list=$($cli get pods -l app=conjur-cli --no-headers | awk '{ print $1 }')
+  echo $pod_list | awk '{print $1}'
+}
+
+get_test_curl_pod_name() {
+  pod_list=$($cli get pods -l app=test-curl --no-headers | awk '{ print $1 }')
   echo $pod_list | awk '{print $1}'
 }
 


### PR DESCRIPTION
### Desired Outcome

Update scripts to use Conjur CLI v8.0.

### Implemented Changes

- Updated `2_prepare_docker_images.sh` script to use version 8 of the Conjur CLI image.
- Update CLI commands to use new syntax
- Add new test-curl pod to test master readiness since the new cli container doesn't contain curl
- Remove support for Conjur v4 in all scripts

### Connected Issue/Story

CyberArk internal issue ID: ONYX-33379

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
