### PR TITLE
Pull seed-fetcher image with tag edge rather than latest

### DIFF
--- a/2_prepare_docker_images.sh
+++ b/2_prepare_docker_images.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 . utils.sh
 
 : "${SEEDFETCHER_IMAGE:=cyberark/dap-seedfetcher}"
+: "${SEEDFETCHER_TAG:=edge}"
 
 main() {
   if [[ "${PLATFORM}" = "openshift" ]]; then
@@ -66,10 +67,10 @@ prepare_conjur_cli_image() {
 prepare_seed_fetcher_image() {
   announce "Pulling and pushing seed-fetcher image."
 
-  docker pull $SEEDFETCHER_IMAGE
+  docker pull "${SEEDFETCHER_IMAGE}:${SEEDFETCHER_TAG}"
 
   seedfetcher_image=$(platform_image seed-fetcher)
-  docker tag $SEEDFETCHER_IMAGE $seedfetcher_image
+  docker tag "${SEEDFETCHER_IMAGE}:${SEEDFETCHER_TAG}" ${seedfetcher_image}
 
   if [ ! is_minienv ] || [ "${DEV}" = "false" ]; then
     docker push $seedfetcher_image


### PR DESCRIPTION
### Desired Outcome

This PR addresses issue with failing pipelines that uses this repository. Currently it is pulling dap-seedfetcher with latest tag that is 5 months old. Instead it should pull the image with tag edge that is up to date with other repositories (such as appliance). It is believed to be the main issue of failing pipelines such as authn-k8s-client.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
