### PR TITLE
Upgrade nginx-base base image to nginx:1.25.2

### DIFF
--- a/oss/nginx_base/Dockerfile
+++ b/oss/nginx_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.6
+FROM nginx:1.25.2
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \


### PR DESCRIPTION
### Desired Outcome

Remove base images that contain vulnerable versions of libwebp to remove any possibility of CVE-2023-4863/CVE-2023-5129

### Implemented Changes

- Upgraded nginx base image in oss/nginx_base to latest version (1.25.2)

### Connected Issue/Story

CyberArk internal issue ID: CNJR-1709

